### PR TITLE
creating one external-dns per hosted zone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# we don't want to check these in, the versions MD uses are very specific
+.terraform.lock.hcl
+
+
 
 # Created by https://www.toptal.com/developers/gitignore/api/terraform,osx,windows,linux
 # Edit at https://www.toptal.com/developers/gitignore?templates=terraform,osx,windows,linux

--- a/k8s-external-dns/_variables.tf
+++ b/k8s-external-dns/_variables.tf
@@ -20,7 +20,13 @@ variable "namespace" {
 
 variable "domain_filters" {
   type        = string
-  description = "a comman-separated list of domains to allow"
+  description = "DEPRECATED: a comman-separated list of domains to allow"
+}
+
+variable "domain_filter_list" {
+  type        = list(any)
+  default     = []
+  description = "a list of domains to allow"
 }
 
 variable "helm_additional_values" {

--- a/k8s-external-dns/_variables.tf
+++ b/k8s-external-dns/_variables.tf
@@ -24,7 +24,7 @@ variable "domain_filters" {
 }
 
 variable "domain_filter_list" {
-  type        = list(any)
+  type        = list(string)
   default     = []
   description = "a list of domains to allow"
 }

--- a/k8s-external-dns/main.tf
+++ b/k8s-external-dns/main.tf
@@ -33,6 +33,6 @@ resource "helm_release" "external-dns" {
     "${file("${path.module}/values.yaml")}",
     yamlencode(local.helm_values),
     yamlencode(var.helm_additional_values),
-    yamlencode({ domainFilters = each.value })
+    yamlencode({ domainFilters = [each.value] })
   ]
 }

--- a/k8s-external-dns/main.tf
+++ b/k8s-external-dns/main.tf
@@ -8,7 +8,7 @@ locals {
     # there's a 1:1 requirement for hosted zone and provider. If multiple are passed in
     # NONE work...
     # https://github.com/kubernetes-sigs/external-dns/issues/1961
-    domainFilters    = split(",", var.domain_filters)
+    domainFilters    = length(var.domain_filter_list) > 0 ? var.domain_filter_list : split(",", var.domain_filters)
     provider         = var.dns_provider # https://github.com/kubernetes-sigs/external-dns/blob/5806e3474f2e13254498bd2af34302a4e283ae39/.github/labeler.yml
     additionalLabels = var.md_metadata.default_tags
   }

--- a/k8s-external-dns/main.tf
+++ b/k8s-external-dns/main.tf
@@ -1,19 +1,24 @@
 locals {
   # k8s this should be the default calculated name anyway, but we want to enforce it just to be sure
   service_account_name = var.release == "external-dns" ? "external-dns" : "${var.release}-external-dns"
+  split_domain_filters = split(",", var.domain_filters)
+  release_name_map = {
+    for domain_filter in local.split_domain_filters :
+    domain_filter => "${var.release}-${replace(domain_filter, ".", "-")}"
+  }
 
   helm_values = {
     serviceAccount = {
       name = local.service_account_name
     }
-    domainFilters    = [var.domain_filters]
     provider         = var.dns_provider # https://github.com/kubernetes-sigs/external-dns/blob/5806e3474f2e13254498bd2af34302a4e283ae39/.github/labeler.yml
     additionalLabels = var.md_metadata.default_tags
   }
 }
 
 resource "helm_release" "external-dns" {
-  name             = var.release
+  for_each         = toset(local.split_domain_filters)
+  name             = local.release_name_map[each.key]
   chart            = "external-dns"
   repository       = "https://kubernetes-sigs.github.io/external-dns/"
   version          = "1.7.1"
@@ -23,6 +28,7 @@ resource "helm_release" "external-dns" {
   values = [
     "${file("${path.module}/values.yaml")}",
     yamlencode(local.helm_values),
-    yamlencode(var.helm_additional_values)
+    yamlencode(var.helm_additional_values),
+    yamlencode({ domainFilters = each.value })
   ]
 }

--- a/k8s-external-dns/main.tf
+++ b/k8s-external-dns/main.tf
@@ -1,28 +1,21 @@
 locals {
   # k8s this should be the default calculated name anyway, but we want to enforce it just to be sure
   service_account_name = var.release == "external-dns" ? "external-dns" : "${var.release}-external-dns"
-  # there's a fun edge-case if you end up using multiple hosted zones!
-  # there's a 1:1 requirement for hosted zone and provider. If multiple are passed in
-  # NONE work...
-  # https://github.com/kubernetes-sigs/external-dns/issues/1961
-  split_domain_filters = split(",", var.domain_filters)
-  release_name_map = {
-    for domain_filter in local.split_domain_filters :
-    domain_filter => "${var.release}-${replace(domain_filter, ".", "-")}"
-  }
-
   helm_values = {
     serviceAccount = {
       name = local.service_account_name
     }
+    # there's a 1:1 requirement for hosted zone and provider. If multiple are passed in
+    # NONE work...
+    # https://github.com/kubernetes-sigs/external-dns/issues/1961
+    domainFilters    = split(",", var.domain_filters)
     provider         = var.dns_provider # https://github.com/kubernetes-sigs/external-dns/blob/5806e3474f2e13254498bd2af34302a4e283ae39/.github/labeler.yml
     additionalLabels = var.md_metadata.default_tags
   }
 }
 
 resource "helm_release" "external-dns" {
-  for_each         = toset(local.split_domain_filters)
-  name             = local.release_name_map[each.key]
+  name             = var.release
   chart            = "external-dns"
   repository       = "https://kubernetes-sigs.github.io/external-dns/"
   version          = "1.7.1"
@@ -32,7 +25,6 @@ resource "helm_release" "external-dns" {
   values = [
     "${file("${path.module}/values.yaml")}",
     yamlencode(local.helm_values),
-    yamlencode(var.helm_additional_values),
-    yamlencode({ domainFilters = [each.value] })
+    yamlencode(var.helm_additional_values)
   ]
 }

--- a/k8s-external-dns/main.tf
+++ b/k8s-external-dns/main.tf
@@ -1,6 +1,10 @@
 locals {
   # k8s this should be the default calculated name anyway, but we want to enforce it just to be sure
   service_account_name = var.release == "external-dns" ? "external-dns" : "${var.release}-external-dns"
+  # there's a fun edge-case if you end up using multiple hosted zones!
+  # there's a 1:1 requirement for hosted zone and provider. If multiple are passed in
+  # NONE work...
+  # https://github.com/kubernetes-sigs/external-dns/issues/1961
   split_domain_filters = split(",", var.domain_filters)
   release_name_map = {
     for domain_filter in local.split_domain_filters :


### PR DESCRIPTION
tested with the following params.

```terraform
{
  "kubernetes_cluster": {},
  "namespace": "default",
  "release": "external-dns",
  "md_metadata": {
    "name_prefix": "foo-the-hank",
    "default_tags": {
      "md-package": "foo-the-hank"
    }
  },
  "dns_provider": "aws",
  "domain_filters": "example.com,very-different-example.com"
}

```

I've culled a lot of the changes to highlight the important parts. Specifically, that the _release_ name is different, and that the `domainFilters` are different as well. 

```

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # helm_release.external-dns["example.com"] will be created
  + resource "helm_release" "external-dns" {
      + chart                      = "external-dns"
...
      + name                       = "external-dns-example-com"
...
      + values                     = [
...
          + jsonencode({}),
          + <<-EOT
                "domainFilters": "example.com"
            EOT,
        ]
    }

  # helm_release.external-dns["very-different-example.com"] will be created
  + resource "helm_release" "external-dns" {
      + chart                      = "external-dns"
...
      + name                       = "external-dns-very-different-example-com"
....
      + values                     = [
...
          + jsonencode({}),
          + <<-EOT
                "domainFilters": "very-different-example.com"
            EOT,
        ]
    }

Plan: 2 to add, 0 to change, 0 to destroy.

```