### PR TITLE
making alarm conditional off of md_metadata

### DIFF
--- a/aws-cloudwatch-alarm/main.tf
+++ b/aws-cloudwatch-alarm/main.tf
@@ -1,5 +1,5 @@
 locals {
-  enable_alarms = var.md_metadata.observability.alarm_channels.aws != null
+  enable_alarms = lookup(var.md_metadata.observability.alarm_channels, "aws", null) != null
 }
 resource "aws_cloudwatch_metric_alarm" "alarm" {
   count      = local.enable_alarms ? 1 : 0

--- a/gcp-monitoring-utilization-threshold/main.tf
+++ b/gcp-monitoring-utilization-threshold/main.tf
@@ -1,9 +1,9 @@
 locals {
-  has_gcp_alarm_channels = lookup(var.md_metadata.observability.alarm_channels, "gcp", null) != null
+  enable_alarms = lookup(var.md_metadata.observability.alarm_channels, "gcp", null) != null
 }
 
 resource "google_monitoring_alert_policy" "alert_policy" {
-  count        = local.has_gcp_alarm_channels ? 1 : 0
+  count        = local.enable_alarms ? 1 : 0
   display_name = var.alarm_name
   combiner     = "OR"
   conditions {

--- a/gcp-monitoring-utilization-threshold/main.tf
+++ b/gcp-monitoring-utilization-threshold/main.tf
@@ -1,9 +1,9 @@
 locals {
-  enable_alarms = var.md_metadata.observability.alarm_channels.gcp != null
+  has_gcp_alarm_channels = lookup(var.md_metadata.observability.alarm_channels, "gcp", null) != null
 }
 
 resource "google_monitoring_alert_policy" "alert_policy" {
-  count        = local.enable_alarms ? 1 : 0
+  count        = local.has_gcp_alarm_channels ? 1 : 0
   display_name = var.alarm_name
   combiner     = "OR"
   conditions {

--- a/gcp-monitoring-utilization-threshold/main.tf
+++ b/gcp-monitoring-utilization-threshold/main.tf
@@ -1,4 +1,9 @@
+locals {
+  enable_alarms = var.md_metadata.observability.alarm_channels.gcp != null
+}
+
 resource "google_monitoring_alert_policy" "alert_policy" {
+  count        = local.enable_alarms ? 1 : 0
   display_name = var.alarm_name
   combiner     = "OR"
   conditions {
@@ -21,9 +26,8 @@ resource "google_monitoring_alert_policy" "alert_policy" {
   }
 
   notification_channels = [
-    var.alarm_notification_channel_grn
+    var.md_metadata.observability.alarm_channels.gcp.id
   ]
 
   user_labels = var.md_metadata.default_tags
 }
-

--- a/gcp-monitoring-utilization-threshold/variables.tf
+++ b/gcp-monitoring-utilization-threshold/variables.tf
@@ -7,10 +7,6 @@ variable "message" {
   type = string
 }
 
-variable "alarm_notification_channel_grn" {
-  type = string
-}
-
 variable "threshold" {
   type = number
 }


### PR DESCRIPTION
```json
{
  "md_metadata": {
    "name_prefix": "foo-the-hank",
    "default_tags": {
      "md-package": "foo-the-hank"
    },
    "observability": {
      "alarm_channels": {
        "gcp": null
      }
    }
  },
  "message": "oh noes",
  "threshold": 90,
  "duration": 60,
  "period": 60,
  "alarm_name": "Hank the dog is worried",
  "metric_type": "GAUGE",
  "resource_type": "cloud-dog"
}

```
<img width="814" alt="Screen Shot 2022-06-10 at 9 10 12 AM" src="https://user-images.githubusercontent.com/651833/173107601-d914c842-0333-486a-a641-99718268e5ac.png">

```json
{
  "md_metadata": {
    "name_prefix": "foo-the-hank",
    "default_tags": {
      "md-package": "foo-the-hank"
    },
    "observability": {
      "alarm_channels": {
        "gcp": {
          "id": "projects/thing/channel/id"
        }
      }
    }
  },
  "message": "oh noes",
  "threshold": 90,
  "duration": 60,
  "period": 60,
  "alarm_name": "Hank the dog is worried",
  "metric_type": "GAUGE",
  "resource_type": "cloud-dog"
}

```
<img width="1209" alt="Screen Shot 2022-06-10 at 9 10 07 AM" src="https://user-images.githubusercontent.com/651833/173107723-3c259994-a768-42a1-ab26-218aa008ded8.png">

