### PR TITLE
Alarm channels

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
-      # - id: terraform_docs
+      - id: terraform_docs
       # - id: terrascan
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,11 @@ repos:
           - --hook-config=--path-to-file=README.md
           - --hook-config=--add-to-existing-file=true
           - --hook-config=--create-file-if-not-exist=true
-      # - id: terrascan
+      - id: terrascan
+        args:
+          - --args=--non-recursive
+          # We set this to high as it suggests KMS keys for SNS Topics which would set a base cost of $1 per bundle...
+          - --args=--severity=high
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: v1.71.0 # Get the latest from: https://github.com/antonbabenko/pre-commit-terraform/releases
     hooks:
       - id: terraform_fmt
-      # - id: terraform_validate
+      - id: terraform_validate
       # - id: terraform_docs
       # - id: terrascan
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,10 @@ repos:
       - id: terraform_fmt
       - id: terraform_validate
       - id: terraform_docs
+        args:
+          - --hook-config=--path-to-file=README.md
+          - --hook-config=--add-to-existing-file=true
+          - --hook-config=--create-file-if-not-exist=true
       # - id: terrascan
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,12 @@ repos:
           - --hook-config=--path-to-file=README.md
           - --hook-config=--add-to-existing-file=true
           - --hook-config=--create-file-if-not-exist=true
-      - id: terrascan
-        args:
-          - --args=--non-recursive
-          # We set this to high as it suggests KMS keys for SNS Topics which would set a base cost of $1 per bundle...
-          - --args=--severity=high
+      # This is picking up a bunch of k8s issues not in this commit...
+      # - id: terrascan
+      #   args:
+      #     - --args=--non-recursive
+      #     # We set this to high as it suggests KMS keys for SNS Topics which would set a base cost of $1 per bundle...
+      #     - --args=--severity=high
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.2.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # terraform-modules
+
+Terraform modules used by Massdriver bundles
+## Development
+
+### Enabling Pre-commit
+
+This repo includes Terraform pre-commit hooks.
+
+[Install precommmit](https://pre-commit.com/index.html#installation) on your system.
+
+```shell
+git init
+pre-commit install
+```
+
+Terraform hooks will now be run on each commit.
+
+You'll additionally need to install:
+
+* [Terrascan](https://github.com/tenable/terrascan)
+* [Terraform Docs](https://github.com/terraform-docs/terraform-docs)

--- a/aws-alarm-channel/README.md
+++ b/aws-alarm-channel/README.md
@@ -28,7 +28,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_md_metadata"></a> [md\_metadata](#input\_md\_metadata) | Massdriver package metadata object. | `any` | n/a | yes |
+| <a name="input_md_metadata"></a> [md\_metadata](#input\_md\_metadata) | Massdriver package metadata object | `any` | n/a | yes |
 
 ## Outputs
 

--- a/aws-alarm-channel/README.md
+++ b/aws-alarm-channel/README.md
@@ -1,3 +1,38 @@
 # AWS Alarm Channel for Massdriver
 
 Create an AWS SNS Topic for receiving Cloudwatch Metric events from bundles.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.18.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_sns_topic.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_sns_topic_subscription.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic_subscription) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_md_metadata"></a> [md\_metadata](#input\_md\_metadata) | Massdriver package metadata object. | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | Alarm Channel AWS SNS Topic ARN |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/aws-alarm-channel/README.md
+++ b/aws-alarm-channel/README.md
@@ -1,0 +1,3 @@
+# AWS Alarm Channel for Massdriver
+
+Create an AWS SNS Topic for receiving Cloudwatch Metric events from bundles.

--- a/aws-alarm-channel/main.tf
+++ b/aws-alarm-channel/main.tf
@@ -1,5 +1,5 @@
 variable "md_metadata" {
-  description = "Massdriver package metadata object."
+  description = "Massdriver package metadata object"
   type        = any
 }
 

--- a/aws-alarm-channel/main.tf
+++ b/aws-alarm-channel/main.tf
@@ -1,0 +1,36 @@
+variable "md_metadata" {
+  description = "Massdriver package metadata object."
+  type        = any
+}
+
+resource "aws_sns_topic" "main" {
+  name         = "${var.md_metadata.name_prefix}-alarms"
+  display_name = "Massdriver Alarms"
+  # https://docs.aws.amazon.com/sns/latest/dg/sns-message-delivery-retries.html
+  delivery_policy = <<EOF
+  {
+    "http": {
+      "defaultHealthyRetryPolicy": {
+        "numNoDelayRetries": 5,
+        "minDelayTarget": 1,
+        "numMinDelayRetries": 5,
+        "maxDelayTarget": 3,
+        "numMaxDelayRetries": 5,
+        "numRetries": 30
+      },
+      "disableSubscriptionOverrides": false
+    }
+  }
+  EOF
+}
+
+resource "aws_sns_topic_subscription" "main" {
+  endpoint  = var.md_metadata.observability.alarm_webhook_url
+  protocol  = "https"
+  topic_arn = aws_sns_topic.main.arn
+}
+
+output "arn" {
+  description = "Alarm Channel AWS SNS Topic ARN"
+  value       = aws_sns_topic.main.arn
+}

--- a/azure-alarm-channel/README.md
+++ b/azure-alarm-channel/README.md
@@ -1,3 +1,38 @@
 # Azure Alarm Channel for Massdriver
 
 Create an Azure Action Group for receiving Azure Monitor metric alerts from bundles.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.10.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_monitor_action_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_action_group) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_md_metadata"></a> [md\_metadata](#input\_md\_metadata) | Massdriver package metadata object. | `any` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Massdriver package Azure Resource Group name | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | Alarm Channel Action Group ID |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/azure-alarm-channel/README.md
+++ b/azure-alarm-channel/README.md
@@ -1,0 +1,3 @@
+# Azure Alarm Channel for Massdriver
+
+Create an Azure Action Group for receiving Azure Monitor metric alerts from bundles.

--- a/azure-alarm-channel/main.tf
+++ b/azure-alarm-channel/main.tf
@@ -10,7 +10,7 @@ variable "resource_group_name" {
 
 resource "azurerm_monitor_action_group" "main" {
   name                = "${var.md_metadata.name_prefix}-alarms"
-  short_name          = "Massdriver Alarms"
+  short_name          = "MD Alarms"
   resource_group_name = var.resource_group_name
 
   webhook_receiver {

--- a/azure-alarm-channel/main.tf
+++ b/azure-alarm-channel/main.tf
@@ -1,0 +1,26 @@
+variable "md_metadata" {
+  description = "Massdriver package metadata object."
+  type        = any
+}
+
+variable "resource_group_name" {
+  description = "Massdriver package Azure Resource Group name"
+  type        = string
+}
+
+resource "azurerm_monitor_action_group" "main" {
+  name                = "${var.md_metadata.name_prefix}-alarms"
+  short_name          = "Massdriver Alarms"
+  resource_group_name = var.resource_group_name
+
+  webhook_receiver {
+    name                    = "Massdriver Observability Webhook API"
+    service_uri             = var.md_metadata.observability.alarm_webhook_url
+    use_common_alert_schema = true
+  }
+}
+
+output "id" {
+  description = "Alarm Channel Action Group ID"
+  value       = azurerm_monitor_action_group.main.id
+}

--- a/gcp-alarm-channel/README.md
+++ b/gcp-alarm-channel/README.md
@@ -17,7 +17,7 @@ No requirements.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_apis"></a> [apis](#module\_apis) | github.com/massdriver-cloud/terraform-modules//google-enable-apis | 9201b9f |
+| <a name="module_apis"></a> [apis](#module\_apis) | github.com/massdriver-cloud/terraform-modules//gcp-enable-apis | c46bc59 |
 
 ## Resources
 
@@ -29,7 +29,7 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_md_metadata"></a> [md\_metadata](#input\_md\_metadata) | Massdriver package metadata object. | `any` | n/a | yes |
+| <a name="input_md_metadata"></a> [md\_metadata](#input\_md\_metadata) | Massdriver package metadata object | `any` | n/a | yes |
 
 ## Outputs
 

--- a/gcp-alarm-channel/README.md
+++ b/gcp-alarm-channel/README.md
@@ -1,0 +1,3 @@
+# GCP Alarm Channel for Massdriver
+
+Create a Monitoring Notification Channel for receiving GCP Monitoring alerts from bundles.

--- a/gcp-alarm-channel/README.md
+++ b/gcp-alarm-channel/README.md
@@ -1,3 +1,39 @@
 # GCP Alarm Channel for Massdriver
 
 Create a Monitoring Notification Channel for receiving GCP Monitoring alerts from bundles.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | 4.24.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_apis"></a> [apis](#module\_apis) | github.com/massdriver-cloud/terraform-modules//google-enable-apis | 9201b9f |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_monitoring_notification_channel.main](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_notification_channel) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_md_metadata"></a> [md\_metadata](#input\_md\_metadata) | Massdriver package metadata object. | `any` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | Alarm Channel Monitoring Notification Channel ID |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/gcp-alarm-channel/main.tf
+++ b/gcp-alarm-channel/main.tf
@@ -1,16 +1,16 @@
 variable "md_metadata" {
-  description = "Massdriver package metadata object."
+  description = "Massdriver package metadata object"
   type        = any
 }
 
 module "apis" {
-  source   = "github.com/massdriver-cloud/terraform-modules//google-enable-apis?ref=9201b9f"
+  source   = "github.com/massdriver-cloud/terraform-modules//gcp-enable-apis?ref=c46bc59"
   services = ["monitoring.googleapis.com"]
 }
 
 resource "google_monitoring_notification_channel" "main" {
   depends_on   = [module.apis]
-  display_name = "Massdriver Alarms"
+  display_name = "${var.md_metadata.name_prefix}-alarms"
 
   type = "webhook_tokenauth"
   labels = {

--- a/gcp-alarm-channel/main.tf
+++ b/gcp-alarm-channel/main.tf
@@ -1,0 +1,27 @@
+variable "md_metadata" {
+  description = "Massdriver package metadata object."
+  type        = any
+}
+
+module "apis" {
+  source   = "github.com/massdriver-cloud/terraform-modules//google-enable-apis?ref=9201b9f"
+  services = ["monitoring.googleapis.com"]
+}
+
+resource "google_monitoring_notification_channel" "main" {
+  depends_on   = [module.apis]
+  display_name = "Massdriver Alarms"
+
+  type = "webhook_tokenauth"
+  labels = {
+    url = var.md_metadata.observability.alarm_webhook_url
+  }
+  user_labels = {
+    name_prefix = var.md_metadata.name_prefix
+  }
+}
+
+output "id" {
+  description = "Alarm Channel Monitoring Notification Channel ID"
+  value       = google_monitoring_notification_channel.main.id
+}


### PR DESCRIPTION
In a rush to de-MRC all of our networks, we didn't review the quota limits of each of the clouds notifications services and just followed the same pattern in Satellite. We ran into an issue there that didn't have a non-expensive workaround, dug into quotas and realized that we over optimized for quota sensitivity by moving 'alarm channels' to Satellite.

This creates channels as a module which will be used in each bundle that has alerts.

Side effect, a 'channel' per bundle, all using the same target webhook.

Each of the cloud seem to expect generous usage of their 'alarm channels':

Azure: https://docs.microsoft.com/en-us/azure/azure-monitor/service-limits#action-groups
> You may have an unlimited number of action groups in a subscription.

AWS: https://docs.aws.amazon.com/general/latest/gr/sns.html
> Standard: 100,000 per account

GCP: (log into the quota dashboard)
> 500 alerting policies per project
> Doesnt seem to have a notification channel limit, more on the number of alerting policies…
