### PR TITLE
using md-package instead of name_prefix as label

### DIFF
--- a/gcp-alarm-channel/README.md
+++ b/gcp-alarm-channel/README.md
@@ -11,7 +11,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.24.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | 4.25.0 |
 
 ## Modules
 

--- a/gcp-alarm-channel/main.tf
+++ b/gcp-alarm-channel/main.tf
@@ -17,7 +17,7 @@ resource "google_monitoring_notification_channel" "main" {
     url = var.md_metadata.observability.alarm_webhook_url
   }
   user_labels = {
-    name_prefix = var.md_metadata.name_prefix
+    md-package = var.md_metadata.name_prefix
   }
 }
 


### PR DESCRIPTION
Here's the line in [massdriver](https://github.com/massdriver-cloud/massdriver/blob/main/lib/massdriver/auto_sre/auto_sre.ex#L233)

closes: https://github.com/massdriver-cloud/gcp-subnetwork/issues/3

Fixes what I broke in May: https://github.com/massdriver-cloud/massdriver/commit/da6e02ce9436e0ac25d6ce0b92a9fa01117f96f8

underscores aren't valid in tags, so we moved the backend and never updated the frontend. 