### PR TITLE
adding massdriver package alarm to alarm modules

### DIFF
--- a/aws-cloudwatch-alarm/_providers.tf
+++ b/aws-cloudwatch-alarm/_providers.tf
@@ -1,9 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
   required_providers {
-    google = {
-      source = "hashicorp/google"
-    }
     massdriver = {
       source  = "massdriver-cloud/massdriver"
       version = "~> 1.0"

--- a/aws-cloudwatch-alarm/_providers.tf
+++ b/aws-cloudwatch-alarm/_providers.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     massdriver = {
       source  = "massdriver-cloud/massdriver"
-      version = "~> 1.0"
     }
   }
 }

--- a/aws-cloudwatch-alarm/_variables.tf
+++ b/aws-cloudwatch-alarm/_variables.tf
@@ -57,3 +57,8 @@ variable "dimensions" {
   type        = map(string)
   description = "The value against which the specified statistic is compared."
 }
+
+variable "display_name" {
+  type        = string
+  description = "Short name to display in the massdriver UI."
+}

--- a/aws-cloudwatch-alarm/main.tf
+++ b/aws-cloudwatch-alarm/main.tf
@@ -21,3 +21,8 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
   alarm_actions   = [var.sns_topic_arn]
   ok_actions      = [var.sns_topic_arn]
 }
+
+resource "massdriver_package_alarm" "package_alarm" {
+  display_name      = var.display_name
+  cloud_provider_id = aws_cloudwatch_metric_alarm.alarm.arn
+}

--- a/aws-cloudwatch-alarm/main.tf
+++ b/aws-cloudwatch-alarm/main.tf
@@ -24,5 +24,5 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
 
 resource "massdriver_package_alarm" "package_alarm" {
   display_name      = var.display_name
-  cloud_provider_id = aws_cloudwatch_metric_alarm.alarm.arn
+  cloud_resource_id = aws_cloudwatch_metric_alarm.alarm.arn
 }

--- a/azure-monitor-metrics-alarm/_providers.tf
+++ b/azure-monitor-metrics-alarm/_providers.tf
@@ -1,9 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
   required_providers {
-    google = {
-      source = "hashicorp/google"
-    }
     massdriver = {
       source  = "massdriver-cloud/massdriver"
       version = "~> 1.0"

--- a/azure-monitor-metrics-alarm/_providers.tf
+++ b/azure-monitor-metrics-alarm/_providers.tf
@@ -2,7 +2,6 @@ terraform {
   required_providers {
     massdriver = {
       source  = "massdriver-cloud/massdriver"
-      version = "~> 1.0"
     }
   }
 }

--- a/azure-monitor-metrics-alarm/_variables.tf
+++ b/azure-monitor-metrics-alarm/_variables.tf
@@ -77,3 +77,8 @@ variable "dimensions" {
   )
   default = []
 }
+
+variable "display_name" {
+  type        = string
+  description = "Short name to display in the massdriver UI."
+}

--- a/azure-monitor-metrics-alarm/main.tf
+++ b/azure-monitor-metrics-alarm/main.tf
@@ -34,5 +34,5 @@ resource "azurerm_monitor_metric_alert" "main" {
 
 resource "massdriver_package_alarm" "package_alarm" {
   display_name      = var.display_name
-  cloud_provider_id = azurerm_monitor_metric_alert.main.id
+  cloud_resource_id = azurerm_monitor_metric_alert.main.id
 }

--- a/azure-monitor-metrics-alarm/main.tf
+++ b/azure-monitor-metrics-alarm/main.tf
@@ -31,3 +31,8 @@ resource "azurerm_monitor_metric_alert" "main" {
   }
   tags = var.md_metadata.default_tags
 }
+
+resource "massdriver_package_alarm" "package_alarm" {
+  display_name      = var.display_name
+  cloud_provider_id = azurerm_monitor_metric_alert.main.id
+}

--- a/gcp-monitoring-utilization-threshold/_providers.tf
+++ b/gcp-monitoring-utilization-threshold/_providers.tf
@@ -5,7 +5,6 @@ terraform {
     }
     massdriver = {
       source  = "massdriver-cloud/massdriver"
-      version = "~> 1.0"
     }
   }
 }

--- a/gcp-monitoring-utilization-threshold/main.tf
+++ b/gcp-monitoring-utilization-threshold/main.tf
@@ -29,5 +29,5 @@ resource "google_monitoring_alert_policy" "alert_policy" {
 
 resource "massdriver_package_alarm" "package_alarm" {
   display_name      = var.display_name
-  cloud_provider_id = google_monitoring_alert_policy.alert_policy.name
+  cloud_resource_id = google_monitoring_alert_policy.alert_policy.name
 }

--- a/gcp-monitoring-utilization-threshold/main.tf
+++ b/gcp-monitoring-utilization-threshold/main.tf
@@ -26,3 +26,8 @@ resource "google_monitoring_alert_policy" "alert_policy" {
 
   user_labels = var.md_metadata.default_tags
 }
+
+resource "massdriver_package_alarm" "package_alarm" {
+  display_name      = var.display_name
+  cloud_provider_id = google_monitoring_alert_policy.alert_policy.name
+}

--- a/gcp-monitoring-utilization-threshold/providers.tf
+++ b/gcp-monitoring-utilization-threshold/providers.tf
@@ -1,5 +1,4 @@
 terraform {
-  required_version = ">= 1.0"
   required_providers {
     google = {
       source = "hashicorp/google"

--- a/gcp-monitoring-utilization-threshold/variables.tf
+++ b/gcp-monitoring-utilization-threshold/variables.tf
@@ -34,3 +34,8 @@ variable "metric_type" {
 variable "resource_type" {
   type = string
 }
+
+variable "display_name" {
+  type        = string
+  description = "Short name to display in the massdriver UI."
+}


### PR DESCRIPTION
Adding new massdriver package alarm resource to alarm channels modules for GCP Azure and AWS.