### PR TITLE
use var.alarm_name attribute to match alert json

### DIFF
--- a/gcp-monitoring-utilization-threshold/README.md
+++ b/gcp-monitoring-utilization-threshold/README.md
@@ -1,15 +1,14 @@
 # terraform-google-monitoring-utilization-threshold<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+No requirements.
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | 4.24.0 |
+| <a name="provider_massdriver"></a> [massdriver](#provider\_massdriver) | 1.1.2 |
 
 ## Modules
 
@@ -20,12 +19,14 @@ No modules.
 | Name | Type |
 |------|------|
 | [google_monitoring_alert_policy.alert_policy](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/monitoring_alert_policy) | resource |
+| [massdriver_package_alarm.package_alarm](https://registry.terraform.io/providers/massdriver-cloud/massdriver/latest/docs/resources/package_alarm) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alarm_name"></a> [alarm\_name](#input\_alarm\_name) | n/a | `string` | n/a | yes |
+| <a name="input_display_name"></a> [display\_name](#input\_display\_name) | Short name to display in the massdriver UI. | `string` | n/a | yes |
 | <a name="input_duration"></a> [duration](#input\_duration) | n/a | `string` | n/a | yes |
 | <a name="input_md_metadata"></a> [md\_metadata](#input\_md\_metadata) | Massdriver Variables | `any` | n/a | yes |
 | <a name="input_message"></a> [message](#input\_message) | n/a | `string` | n/a | yes |

--- a/gcp-monitoring-utilization-threshold/_providers.tf
+++ b/gcp-monitoring-utilization-threshold/_providers.tf
@@ -4,7 +4,7 @@ terraform {
       source = "hashicorp/google"
     }
     massdriver = {
-      source  = "massdriver-cloud/massdriver"
+      source = "massdriver-cloud/massdriver"
     }
   }
 }

--- a/gcp-monitoring-utilization-threshold/main.tf
+++ b/gcp-monitoring-utilization-threshold/main.tf
@@ -29,5 +29,5 @@ resource "google_monitoring_alert_policy" "alert_policy" {
 
 resource "massdriver_package_alarm" "package_alarm" {
   display_name      = var.display_name
-  cloud_resource_id = google_monitoring_alert_policy.alert_policy.display_name
+  cloud_resource_id = var.alarm_name
 }

--- a/gcp-monitoring-utilization-threshold/main.tf
+++ b/gcp-monitoring-utilization-threshold/main.tf
@@ -29,5 +29,5 @@ resource "google_monitoring_alert_policy" "alert_policy" {
 
 resource "massdriver_package_alarm" "package_alarm" {
   display_name      = var.display_name
-  cloud_resource_id = google_monitoring_alert_policy.alert_policy.name
+  cloud_resource_id = google_monitoring_alert_policy.alert_policy.display_name
 }


### PR DESCRIPTION
# GCP alarm investigation

gcp-alarm-channel.tf

```terraform
description = "Alarm Channel Monitoring Notification Channel ID"
value       = google_monitoring_notification_channel.main.id
```

gcp-monitoring-utilization-threshold.tf

```terraform
resource "massdriver_package_alarm" "package_alarm" {
  display_name      = var.display_name
  cloud_resource_id = google_monitoring_alert_policy.alert_policy.name
}
```

TF apply redis bundle locally, `terraform state show XYZ` we see.

```
# module.topic_bytes_alarm.google_monitoring_alert_policy.alert_policy:
resource "google_monitoring_alert_policy" "alert_policy" {
    id                    = "projects/md-wbeebe-0603/alertPolicies/16665473838734147203"
    name                  = "projects/md-wbeebe-0603/alertPolicies/16665473838734147203"
    notification_channels = [
        "projects/md-wbeebe-0603/notificationChannels/8518021308845210337",
    ]
}
```

That seems fine..., the provider also looks good, let's see what the backend looks like.

https://github.com/massdriver-cloud/massdriver/blob/main/test/support/cloud_alarm_case.ex#L131

```
        "metadata" => %{
          "user_labels" => %{"md-package" => name_prefix}
        },
        # this is what should match
        "policy_name" => provider_resource_id,
        "policy_user_labels" => %{
          "user-label-1" => "important label",
          "user-label-2" => "another label"
        },
```

Results from ngrok, using "test webhook"

```
    "policy_name": "projects/12345/alertPolicies/12345",
    "policy_user_labels": {
        "example": "label"
    },
    "documentation": "Test documentation",
    "condition": {
```

Hmm, this looks good too. `projects/p1/alertPolicies/id`.

Next up, Ngrok of "real" GCP alert => alarm.

```json
{
  "incident": {
    "condition": {
      "conditionThreshold": {
        "aggregations": [
          {
            "alignmentPeriod": "60s",
            "crossSeriesReducer": "REDUCE_MEAN",
            "perSeriesAligner": "ALIGN_MAX"
          }
        ],
        "comparison": "COMPARISON_GT",
        "duration": "60s",
        "filter": "resource.type = \"pubsub_topic\" AND metric.type = \"pubsub.googleapis.com/topic/retained_bytes\" AND metadata.user_labels.md-package = \"testpol-morepro-alarms-p7vd\"",
        "thresholdValue": 100000,
        "trigger": {
          "count": 1
        }
      },
      "displayName": "projects/md-wbeebe-0603/topics/testpol-morepro-alarms-p7vd-retainedBytes COMPARISON_GT",
      "name": "projects/md-wbeebe-0603/alertPolicies/8590711779795284828/conditions/10146620168134649986"
    },
    "condition_name": "projects/md-wbeebe-0603/topics/testpol-morepro-alarms-p7vd-retainedBytes COMPARISON_GT",
    "ended_at": null,
    "incident_id": "0.mjggzaivhp1c",
    "metadata": {
      "system_labels": {},
      "user_labels": {
        "md-package": "testpol-morepro-alarms-p7vd"
      }
    },
    "metric": {
      "displayName": "Retained bytes",
      "labels": {},
      "type": "pubsub.googleapis.com/topic/retained_bytes"
    },
    "observed_value": "135000.000",
    // uhhh this, key "policy_name" has "topics" in it, which is different than the TF _policy_ id
    // AND different than the test webhook payload....
    // looking at the Terraform again we have:
    // display_name          = "projects/md-wbeebe-0603/topics/thing-me-thing-you-retainedBytes"
    // enabled                   = true
    // id                             = "projects/md-wbeebe-0603/alertPolicies/16665473838734147203"
    // name                       = "projects/md-wbeebe-0603/alertPolicies/16665473838734147203"
    // notification_channels = [
    //     "projects/md-wbeebe-0603/notificationChannels/8518021308845210337",
    // ]
    // I think this is a _bug_ in GCP
    "policy_name": "projects/md-wbeebe-0603/topics/testpol-morepro-alarms-p7vd-retainedBytes",
    "policy_user_labels": {
      "managed-by": "massdriver",
      "md-manifest": "alarms",
      "md-package": "testpol-morepro-alarms-p7vd",
      "md-project": "testpol",
      "md-target": "morepro"
    },
    "resource": {
      "labels": {
        "project_id": "md-wbeebe-0603"
      },
      "type": "pubsub_topic"
    },
    "resource_id": "",
    "resource_name": "md-wbeebe-0603 Cloud Pub/Sub Topic labels {project_id=md-wbeebe-0603}",
    "resource_type_display_name": "Cloud Pub/Sub Topic",
    "scoping_project_id": "md-wbeebe-0603",
    "scoping_project_number": 45075164410,
    "started_at": 1655922219,
    "state": "open",
    "summary": "Retained bytes for md-wbeebe-0603 Cloud Pub/Sub Topic labels {project_id=md-wbeebe-0603} with metadata labels {md-package=testpol-morepro-alarms-p7vd} is above the threshold of 100000.000 with a value of 135000.000.",
    "threshold_value": "100000",
    "url": "https://console.cloud.google.com/monitoring/alerting/incidents/0.mjggzaivhp1c?project=md-wbeebe-0603"
  },
  "version": "1.2"
}
```

I beleive the fix is...

gcp-monitoring-utilization-threshold.tf

```terraform
resource "massdriver_package_alarm" "package_alarm" {
  display_name      = var.display_name
  cloud_resource_id = google_monitoring_alert_policy.alert_policy.display_name
}
```

Testing the change locally w `dev.tfvars.json`

```json
{
  "md_metadata": {
    "name_prefix": "foo-the-hank-0000",
    "default_tags": {
      "md-package": "foo-the-hank-0000"
    },
    "observability": {
      "alarm_channels": {}
    }
  },
  "display_name": "Hank the dog is worried",
  "notification_channel_id": "beth-lives-here",
  "message": "oh noes",
  "threshold": 90,
  "duration": 60,
  "period": 60,
  "alarm_name": "foo-the-hank-0000-alarms",
  "metric_type": "GAUGE",
  "resource_type": "cloud-dog"
}
```

Terraform plan:

```
  # google_monitoring_alert_policy.alert_policy will be created
  + resource "google_monitoring_alert_policy" "alert_policy" {
      + combiner              = "OR"
      + creation_record       = (known after apply)
      + display_name          = "foo-the-hank-0000-alarms"
      + enabled               = true
      + id                    = (known after apply)
      + name                  = (known after apply)
      + notification_channels = [
          + "beth-lives-here",
        ]
      + project               = (known after apply)
      + user_labels           = {
          + "md-package" = "foo-the-hank-0000"
        }

      + conditions {
          + display_name = "foo-the-hank-0000-alarms COMPARISON_GT"
          + name         = (known after apply)

          + condition_threshold {
              + comparison      = "COMPARISON_GT"
              + duration        = "60s"
              + filter          = "metric.type=\"GAUGE\" AND resource.type=\"cloud-dog\" AND metadata.user_labels.md-package=\"foo-the-hank-0000\""
              + threshold_value = 90

              + aggregations {
                  + alignment_period     = "60s"
                  + cross_series_reducer = "REDUCE_MEAN"
                  + per_series_aligner   = "ALIGN_MAX"
                }

              + trigger {
                  + count = 1
                }
            }
        }
    }

  # massdriver_package_alarm.package_alarm will be created
  + resource "massdriver_package_alarm" "package_alarm" {
      # closer, but we need the whole path
      + cloud_resource_id = "foo-the-hank-0000-alarms"
      + display_name      = "Hank the dog is worried"
      + id                = (known after apply)
      + last_updated      = (known after apply)
    }
```

Taking a look at PubSub `monitoring.tf`

```
module "topic_bytes_alarm" {
  source                  = "github.com/massdriver-cloud/terraform-modules//gcp-monitoring-utilization-threshold?ref=8997456"
  notification_channel_id = module.alarm_channel.id
  md_metadata             = var.md_metadata
  display_name            = "Retained Bytes"
  message                 = "PubSub Topic ${var.md_metadata.name_prefix} is above retainedBytes threshold of ${local.threshold_retained_bytes}"
  # ahhhhhh, this has got to be it.
  # from the alert json:
  # "policy_name": "projects/md-wbeebe-0603/topics/testpol-morepro-alarms-p7vd-retainedBytes",
  alarm_name              = "${google_pubsub_topic.main.id}-retainedBytes"
  metric_type             = local.metrics["retained_bytes"].metric
  resource_type           = local.metrics["retained_bytes"].resource
  threshold               = local.threshold_retained_bytes
  period                  = 60
  duration                = 60

  depends_on = [
    google_pubsub_topic.main
  ]
}
```

Okay, I think I've got it now. If we use the alarm name (resource id + md_name_prefix + alarm suffix) it should match.

```terraform
resource "massdriver_package_alarm" "package_alarm" {
  display_name         = var.display_name
  cloud_resource_id = var.alarm_name
}
```
