### PR TITLE
use 3.x tls provider.

### DIFF
--- a/k8s-opensearch/_providers.tf
+++ b/k8s-opensearch/_providers.tf
@@ -9,7 +9,7 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      verssion = ">= 4.0"
+      version = "= 3.1.0"
     }
   }
 }

--- a/k8s-opensearch/_providers.tf
+++ b/k8s-opensearch/_providers.tf
@@ -9,7 +9,6 @@ terraform {
     }
     tls = {
       source  = "hashicorp/tls"
-      version = "= 3.1.0"
     }
   }
 }

--- a/k8s-opensearch/_providers.tf
+++ b/k8s-opensearch/_providers.tf
@@ -7,5 +7,9 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      verssion = ">= 4.0"
+    }
   }
 }

--- a/k8s-opensearch/tls.tf
+++ b/k8s-opensearch/tls.tf
@@ -7,6 +7,7 @@ resource "tls_private_key" "opensearch" {
 
 resource "tls_self_signed_cert" "opensearch" {
   count = true ? 1 : 0
+  key_algorithm = "ECDSA"
   private_key_pem = tls_private_key.opensearch[0].private_key_pem
   subject {
     common_name  = "massdriver.cloud"


### PR DESCRIPTION
have to use old tls provider for now because https://github.com/massdriver-cloud/massdriver-bundles/issues/367