### PR TITLE
force k8s env values to strings

### DIFF
--- a/massdriver-application-helm/main.tf
+++ b/massdriver-application-helm/main.tf
@@ -6,7 +6,7 @@ locals {
         "md-deployment-id" = lookup(module.application.params.md_metadata.deployment, "id", "")
       }
     }
-    envs = [for key, val in module.application.envs : { name = key, value = val }]
+    envs = [for key, val in module.application.envs : { name = key, value = tostring(val) }]
     ingress = {
       className = "nginx" // TODO: eventually this should come from the kubernetes artifact
       annotations = {


### PR DESCRIPTION
Testing this I ran into an issue with PORT env vars. If it's a number in the connection, it's a number passed to k8s and k8s doesn't allow it.