### PR TITLE
better module interface

### DIFF
--- a/massdriver-application-gcp-cloud-run/README.md
+++ b/massdriver-application-gcp-cloud-run/README.md
@@ -18,7 +18,7 @@ No requirements.
 |------|--------|---------|
 | <a name="module_apis"></a> [apis](#module\_apis) | github.com/massdriver-cloud/terraform-modules//google-enable-apis | 9201b9f |
 | <a name="module_application"></a> [application](#module\_application) | github.com/massdriver-cloud/terraform-modules//massdriver-application | n/a |
-| <a name="module_serverless_endpoint"></a> [serverless\_endpoint](#module\_serverless\_endpoint) | github.com/massdriver-cloud/terraform-modules//gcp-serverless-endpoint | 81734ff |
+| <a name="module_serverless_endpoint"></a> [serverless\_endpoint](#module\_serverless\_endpoint) | github.com/massdriver-cloud/terraform-modules//gcp-serverless-endpoint | c00db94 |
 
 ## Resources
 
@@ -33,12 +33,11 @@ No requirements.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_container_image"></a> [container\_image](#input\_container\_image) | n/a | `string` | n/a | yes |
+| <a name="input_endpoint"></a> [endpoint](#input\_endpoint) | n/a | `any` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
 | <a name="input_max_instances"></a> [max\_instances](#input\_max\_instances) | n/a | `number` | n/a | yes |
 | <a name="input_network"></a> [network](#input\_network) | n/a | `string` | n/a | yes |
-| <a name="input_subdomain"></a> [subdomain](#input\_subdomain) | n/a | `string` | `null` | no |
 | <a name="input_vpc_connector_cidr"></a> [vpc\_connector\_cidr](#input\_vpc\_connector\_cidr) | n/a | `string` | `null` | no |
-| <a name="input_zone"></a> [zone](#input\_zone) | n/a | `string` | `null` | no |
 
 ## Outputs
 

--- a/massdriver-application-gcp-cloud-run/endpoint.tf
+++ b/massdriver-application-gcp-cloud-run/endpoint.tf
@@ -1,10 +1,10 @@
 module "serverless_endpoint" {
-  count                  = (var.zone != null && var.subdomain != null) ? 1 : 0
+  count                  = var.endpoint.enabled ? 1 : 0
   source                 = "github.com/massdriver-cloud/terraform-modules//gcp-serverless-endpoint?ref=c00db94"
   resource_name          = module.application.params.md_metadata.name_prefix
   labels                 = module.application.params.md_metadata.default_tags
-  zone                   = var.zone
-  subdomain              = var.subdomain
+  zone                   = var.endpoint.zone.name
+  subdomain              = var.endpoint.subdomain
   location               = var.location
   cloud_run_service_name = google_cloud_run_service.main.name
   depends_on = [

--- a/massdriver-application-gcp-cloud-run/iam.tf
+++ b/massdriver-application-gcp-cloud-run/iam.tf
@@ -1,5 +1,5 @@
 resource "google_cloud_run_service_iam_member" "public-access" {
-  count    = (var.zone != null && var.subdomain != null) ? 1 : 0
+  count    = var.endpoint.enabled ? 1 : 0
   location = google_cloud_run_service.main.location
   project  = google_cloud_run_service.main.project
   service  = google_cloud_run_service.main.name

--- a/massdriver-application-gcp-cloud-run/variables.tf
+++ b/massdriver-application-gcp-cloud-run/variables.tf
@@ -14,14 +14,8 @@ variable "network" {
   type = string
 }
 
-variable "zone" {
-  type    = string
-  default = null
-}
-
-variable "subdomain" {
-  type    = string
-  default = null
+variable "endpoint" {
+  type = any
 }
 
 variable "vpc_connector_cidr" {


### PR DESCRIPTION
these changes were made to clean up the app template module

Related to:
https://github.com/massdriver-cloud/application-templates/pull/24

Terraform `1.3.0` introduces optional vars in variables of type object. With that, we can go from `any` for our endpoint variable to something like this.

```terraform
variable "endpoint" {
  type = object({
    enabled   = bool
    zone      = optional(string)
    subdomain = optional(string)
  })
}
```