### PR TITLE
conditionally create the application identity if one isn't passed

### DIFF
--- a/massdriver-application/outputs.tf
+++ b/massdriver-application/outputs.tf
@@ -23,5 +23,5 @@ output "params" {
 
 output "id" {
   description = "Cloud ID for application IAM (AWS Role, GCP Service Account, Azure Service Account, etc)"
-  value       = mdxc_application_identity.main.id
+  value       = local.application_identity_id
 }

--- a/massdriver-application/variables.tf
+++ b/massdriver-application/variables.tf
@@ -23,3 +23,15 @@ variable "kubernetes" {
     cluster_artifact = any
   })
 }
+
+variable "create_application_identity" {
+  description = "If an application identity already exists, you can specify it here to skip the process of creating a new application identity."
+  type        = bool
+  default     = true
+}
+
+variable "application_identity_id" {
+  description = "If an application identity already exists, you can specify it here to skip the process of creating a new application identity."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
Azure is a bit different in how they manage "identities" for things like App Service and Function App.

Instead of creating a separate entity (like a service principal - or in AWS an IAM Role or GCP a Service Account), Azure allows you to bind permissions to the App Service entity itself. It would be like instead of associating a role with permissions to an AWS lambda, you bind permission to the Lambda itself.

This has a few benefits, and one drawback.
Benefits:
* We don't create an unnecessary external identity (and credentials) to manage
* Permissions are literally bound to the thing that uses them (instead of an intermediary identity) which increases security
* This is Azure's best-practice recommended way

Drawbacks

* The entity is not re-usable (but this isn't a drawback for us at all - in fact it fits our model perfectly!)

The problem is (was?) that the application module always created an identity (in Azure that would be an Application + Service Principal). This change makes it so the application identity creation is conditional depending on whether an identity is passed. This way in Azure we can make the App Service first, pass the App Service ID as the identity, and get all the benefits of this powerful module.