### PR TITLE
app service uses subnet

### DIFF
--- a/massdriver-application-azure-app-service/README.md
+++ b/massdriver-application-azure-app-service/README.md
@@ -1,0 +1,53 @@
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_application"></a> [application](#module\_application) | github.com/massdriver-cloud/terraform-modules//massdriver-application | 9e3a1b4 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_app_service_certificate_binding.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_certificate_binding) | resource |
+| [azurerm_app_service_custom_hostname_binding.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_custom_hostname_binding) | resource |
+| [azurerm_app_service_managed_certificate.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/app_service_managed_certificate) | resource |
+| [azurerm_dns_cname_record.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_cname_record) | resource |
+| [azurerm_dns_txt_record.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dns_txt_record) | resource |
+| [azurerm_linux_web_app.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_web_app) | resource |
+| [azurerm_monitor_autoscale_setting.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_autoscale_setting) | resource |
+| [azurerm_resource_group.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_service_plan.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) | resource |
+| [azurerm_subnet.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_client_config.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_dns_zone.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/dns_zone) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_application"></a> [application](#input\_application) | n/a | <pre>object({<br>    location             = string<br>    sku_name             = string<br>    minimum_worker_count = number<br>    maximum_worker_count = number<br>  })</pre> | n/a | yes |
+| <a name="input_command"></a> [command](#input\_command) | n/a | `string` | `null` | no |
+| <a name="input_contact_email"></a> [contact\_email](#input\_contact\_email) | n/a | `string` | n/a | yes |
+| <a name="input_dns"></a> [dns](#input\_dns) | n/a | `any` | n/a | yes |
+| <a name="input_image"></a> [image](#input\_image) | n/a | <pre>object({<br>    repository = string<br>    tag        = string<br>  })</pre> | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
+| <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | The CIDR block for the subnet. Max size of /24, minimum of /28 | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `any` | n/a | yes |
+| <a name="input_virtual_network_id"></a> [virtual\_network\_id](#input\_virtual\_network\_id) | n/a | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/massdriver-application-azure-app-service/README.md
+++ b/massdriver-application-azure-app-service/README.md
@@ -37,13 +37,12 @@ No requirements.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_application"></a> [application](#input\_application) | n/a | <pre>object({<br>    location             = string<br>    sku_name             = string<br>    minimum_worker_count = number<br>    maximum_worker_count = number<br>  })</pre> | n/a | yes |
+| <a name="input_application"></a> [application](#input\_application) | n/a | <pre>object({<br>    location             = string<br>    cidr                 = string<br>    sku_name             = string<br>    minimum_worker_count = number<br>    maximum_worker_count = number<br>  })</pre> | n/a | yes |
 | <a name="input_command"></a> [command](#input\_command) | n/a | `string` | `null` | no |
 | <a name="input_contact_email"></a> [contact\_email](#input\_contact\_email) | n/a | `string` | n/a | yes |
 | <a name="input_dns"></a> [dns](#input\_dns) | n/a | `any` | n/a | yes |
 | <a name="input_image"></a> [image](#input\_image) | n/a | <pre>object({<br>    repository = string<br>    tag        = string<br>  })</pre> | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
-| <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | The CIDR block for the subnet. Max size of /24, minimum of /28 | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `any` | n/a | yes |
 | <a name="input_virtual_network_id"></a> [virtual\_network\_id](#input\_virtual\_network\_id) | n/a | `string` | n/a | yes |
 

--- a/massdriver-application-azure-app-service/_variables.tf
+++ b/massdriver-application-azure-app-service/_variables.tf
@@ -12,6 +12,7 @@ variable "dns" {
 variable "application" {
   type = object({
     location             = string
+    cidr                 = string
     sku_name             = string
     minimum_worker_count = number
     maximum_worker_count = number
@@ -37,9 +38,4 @@ variable "command" {
 
 variable "virtual_network_id" {
   type = string
-}
-
-variable "subnet_cidr" {
-  type        = string
-  description = "The CIDR block for the subnet. Max size of /24, minimum of /28"
 }

--- a/massdriver-application-azure-app-service/_variables.tf
+++ b/massdriver-application-azure-app-service/_variables.tf
@@ -29,3 +29,17 @@ variable "tags" {
 variable "contact_email" {
   type = string
 }
+
+variable "command" {
+  type    = string
+  default = null
+}
+
+variable "virtual_network_id" {
+  type = string
+}
+
+variable "subnet_cidr" {
+  type        = string
+  description = "The CIDR block for the subnet. Max size of /24, minimum of /28"
+}

--- a/massdriver-application-azure-app-service/auto-scaling.tf
+++ b/massdriver-application-azure-app-service/auto-scaling.tf
@@ -1,0 +1,66 @@
+resource "azurerm_monitor_autoscale_setting" "main" {
+  name                = var.name
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  target_resource_id  = azurerm_service_plan.main.id
+  enabled             = true
+
+  profile {
+    name = "autoscale-profile"
+
+    capacity {
+      default = azurerm_service_plan.main.worker_count
+      minimum = azurerm_service_plan.main.worker_count
+      maximum = var.application.maximum_worker_count
+    }
+
+    rule {
+      metric_trigger {
+        metric_name        = "CpuPercentage"
+        metric_resource_id = azurerm_service_plan.main.id
+        time_grain         = "PT1M"
+        statistic          = "Average"
+        time_window        = "PT5M"
+        time_aggregation   = "Average"
+        operator           = "GreaterThan"
+        threshold          = 75
+      }
+      scale_action {
+        direction = "Increase"
+        type      = "ChangeCount"
+        value     = 1
+        cooldown  = "PT1M"
+      }
+    }
+
+    rule {
+      metric_trigger {
+        metric_name        = "CpuPercentage"
+        metric_resource_id = azurerm_service_plan.main.id
+        time_grain         = "PT5M"
+        statistic          = "Average"
+        time_window        = "PT10M"
+        time_aggregation   = "Average"
+        operator           = "LessThan"
+        threshold          = 25
+      }
+
+      scale_action {
+        direction = "Decrease"
+        type      = "ChangeCount"
+        value     = "1"
+        cooldown  = "PT1M"
+      }
+    }
+  }
+  notification {
+    email {
+      custom_emails = [var.contact_email]
+    }
+  }
+
+  depends_on = [
+    azurerm_service_plan.main
+  ]
+  tags = var.tags
+}

--- a/massdriver-application-azure-app-service/dns.tf
+++ b/massdriver-application-azure-app-service/dns.tf
@@ -1,7 +1,7 @@
 locals {
   zone_split_id       = var.dns.enable_dns ? split("/", var.dns.zone_id) : []
-  zone_name           = var.dns.enable_dns ? element(local.zone_split_id, index(local.zone_split_id, "dnszones") + 1) : null
-  zone_resource_group = var.dns.enable_dns ? element(local.zone_split_id, index(local.zone_split_id, "resourceGroups") + 1) : null
+  zone_name           = var.dns.enable_dns ? regex(".*/dns[z|Z]ones/(.*)$", var.dns.zone_id)[0] : null
+  zone_resource_group = var.dns.enable_dns ? regex(".*/resource[g|G]roups/(.*)/providers", var.dns.zone_id)[0] : null
 }
 
 data "azurerm_dns_zone" "main" {

--- a/massdriver-application-azure-app-service/dns.tf
+++ b/massdriver-application-azure-app-service/dns.tf
@@ -1,7 +1,7 @@
 locals {
   zone_split_id       = var.dns.enable_dns ? split("/", var.dns.zone_id) : []
   zone_name           = var.dns.enable_dns ? element(local.zone_split_id, index(local.zone_split_id, "dnszones") + 1) : null
-  zone_resource_group = var.dns.enable_dns ? element(local.zone_split_id, index(local.zone_split_id, "resourceGroups") + 1): null
+  zone_resource_group = var.dns.enable_dns ? element(local.zone_split_id, index(local.zone_split_id, "resourceGroups") + 1) : null
 }
 
 data "azurerm_dns_zone" "main" {
@@ -38,12 +38,17 @@ resource "azurerm_app_service_custom_hostname_binding" "main" {
   hostname            = join(".", [azurerm_dns_cname_record.main[0].name, azurerm_dns_cname_record.main[0].zone_name])
   app_service_name    = azurerm_linux_web_app.main.name
   resource_group_name = azurerm_resource_group.main.name
+  depends_on = [
+    azurerm_dns_txt_record.main
+  ]
 }
 
 resource "azurerm_app_service_managed_certificate" "main" {
   count                      = var.dns.enable_dns ? 1 : 0
   custom_hostname_binding_id = azurerm_app_service_custom_hostname_binding.main[0].id
-  tags                       = var.tags
+  # Tags are listed as additions in every plan
+  # https://github.com/hashicorp/terraform-provider-azurerm/issues/11816
+  tags = var.tags
 }
 
 resource "azurerm_app_service_certificate_binding" "main" {

--- a/massdriver-application-azure-app-service/main.tf
+++ b/massdriver-application-azure-app-service/main.tf
@@ -22,73 +22,6 @@ resource "azurerm_service_plan" "main" {
   tags                = var.tags
 }
 
-resource "azurerm_monitor_autoscale_setting" "main" {
-  name                = var.name
-  resource_group_name = azurerm_resource_group.main.name
-  location            = azurerm_resource_group.main.location
-  target_resource_id  = azurerm_service_plan.main.id
-  enabled             = true
-
-  profile {
-    name = "autoscale-profile"
-
-    capacity {
-      default = azurerm_service_plan.main.worker_count
-      minimum = azurerm_service_plan.main.worker_count
-      maximum = var.application.maximum_worker_count
-    }
-
-    rule {
-      metric_trigger {
-        metric_name        = "CpuPercentage"
-        metric_resource_id = azurerm_service_plan.main.id
-        time_grain         = "PT1M"
-        statistic          = "Average"
-        time_window        = "PT5M"
-        time_aggregation   = "Average"
-        operator           = "GreaterThan"
-        threshold          = 75
-      }
-      scale_action {
-        direction = "Increase"
-        type      = "ChangeCount"
-        value     = 1
-        cooldown  = "PT1M"
-      }
-    }
-
-    rule {
-      metric_trigger {
-        metric_name        = "CpuPercentage"
-        metric_resource_id = azurerm_service_plan.main.id
-        time_grain         = "PT5M"
-        statistic          = "Average"
-        time_window        = "PT10M"
-        time_aggregation   = "Average"
-        operator           = "LessThan"
-        threshold          = 25
-      }
-
-      scale_action {
-        direction = "Decrease"
-        type      = "ChangeCount"
-        value     = "1"
-        cooldown  = "PT1M"
-      }
-    }
-  }
-  notification {
-    email {
-      custom_emails = [var.contact_email]
-    }
-  }
-
-  depends_on = [
-    azurerm_service_plan.main
-  ]
-  tags = var.tags
-}
-
 resource "azurerm_linux_web_app" "main" {
   name                = var.name
   location            = azurerm_resource_group.main.location
@@ -100,6 +33,22 @@ resource "azurerm_linux_web_app" "main" {
   identity {
     type = "SystemAssigned"
   }
+
+  # To get application logs, we need to set app logging level and retention.
+  logs {
+    application_logs {
+      file_system_level = "Error"
+    }
+    http_logs {
+      file_system {
+        retention_in_days = 7
+        retention_in_mb   = 35
+      }
+    }
+  }
+
+  # https://learn.microsoft.com/en-us/azure/app-service/overview-vnet-integration#regional-virtual-network-integration
+  virtual_network_subnet_id = azurerm_subnet.main.id
 
   site_config {
     always_on                               = true
@@ -134,6 +83,8 @@ resource "azurerm_linux_web_app" "main" {
       docker_image     = var.image.repository
       docker_image_tag = var.image.tag
     }
+
+    app_command_line = var.command
   }
 
   app_settings = module.application.envs

--- a/massdriver-application-azure-app-service/subnet.tf
+++ b/massdriver-application-azure-app-service/subnet.tf
@@ -31,7 +31,7 @@ resource "azurerm_subnet" "main" {
   name                 = var.name
   resource_group_name  = local.resource_group_name
   virtual_network_name = local.network_name
-  address_prefixes     = [var.subnet_cidr]
+  address_prefixes     = [var.application.cidr]
 
   delegation {
     name = "virtual-network-integration"

--- a/massdriver-application-azure-app-service/subnet.tf
+++ b/massdriver-application-azure-app-service/subnet.tf
@@ -1,0 +1,44 @@
+locals {
+  split_id            = split("/", var.virtual_network_id)
+  network_name        = element(local.split_id, index(local.split_id, "virtualNetworks") + 1)
+  resource_group_name = element(local.split_id, index(local.split_id, "resourceGroups") + 1)
+}
+
+# This subnet is for the IPs of the Azure App Service instances.
+# For App Service instances to be able to access things in the VNet,
+# we create this subnet and make use of "Virtual network integration".
+#
+# "Virtual network integration depends on a dedicated subnet.
+# When you create a subnet, the Azure subnet loses five IPs
+# from the start. One address is used from the integration
+# subnet for each plan instance. If you scale your app to four
+# instances, then four addresses are used.""
+#
+# The max scale for Azure App Service
+# Default: 10
+# Isolated tier (max?): 100
+# So we need 105
+# But when scaling, max is doubled.... so 210
+# CIDR minus 5, halved and floored
+# /28 16 - 5 = 11 => 5
+# /27 32 - 5 = 27 => 13
+# /26 64 - 5 = 59 => 29
+# /25 128 - 5 = 123 => 61
+# /24 256 - 5 = 251 => 125
+# Ideally, Massdriver picks an IP range that is not in use
+# and is a /24 so we can handle max scale of App Service.
+resource "azurerm_subnet" "main" {
+  name                 = var.name
+  resource_group_name  = local.resource_group_name
+  virtual_network_name = local.network_name
+  address_prefixes     = [var.subnet_cidr]
+
+  delegation {
+    name = "virtual-network-integration"
+
+    service_delegation {
+      name    = "Microsoft.Web/serverFarms"
+      actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
+    }
+  }
+}

--- a/massdriver-application-azure-app-service/subnet.tf
+++ b/massdriver-application-azure-app-service/subnet.tf
@@ -25,8 +25,10 @@ locals {
 # /26 64 - 5 = 59 => 29
 # /25 128 - 5 = 123 => 61
 # /24 256 - 5 = 251 => 125
+#
 # Ideally, Massdriver picks an IP range that is not in use
 # and is a /24 so we can handle max scale of App Service.
+# For now, we require the user to provide a /24.
 resource "azurerm_subnet" "main" {
   name                 = var.name
   resource_group_name  = local.resource_group_name


### PR DESCRIPTION
These changes are from me testing a few apps on Azure. 

- enables logging for app service apps
- creates a subnet so that the app service can connect to things in the VNet

resolves: https://github.com/massdriver-cloud/application-templates/issues/51