### PR TITLE
Adding default NSG for subnet

### DIFF
--- a/massdriver-application-azure-app-service/subnet.tf
+++ b/massdriver-application-azure-app-service/subnet.tf
@@ -42,3 +42,15 @@ resource "azurerm_subnet" "main" {
     }
   }
 }
+
+resource "azurerm_network_security_group" "main" {
+  name                = var.name
+  resource_group_name = azurerm_subnet.main.resource_group_name
+  location            = var.application.location
+  tags                = var.tags
+}
+
+resource "azurerm_subnet_network_security_group_association" "main" {
+  network_security_group_id = azurerm_network_security_group.main.id
+  subnet_id                 = azurerm_subnet.main.id
+}


### PR DESCRIPTION
Creating a default network security group will set up traffic filter rules to allow all traffic within the virtual network.

This is something we should be creating for all bundles with their own subnet (as well as bundles that create a default subnet).