### PR TITLE
add helm_additional_values variable to helm module

### DIFF
--- a/massdriver-application-helm/main.tf
+++ b/massdriver-application-helm/main.tf
@@ -71,6 +71,7 @@ resource "helm_release" "application" {
   values = [
     fileexists("${var.chart}/values.yaml") ? file("${var.chart}/values.yaml") : "",
     yamlencode(module.application.params),
+    yamlencode(var.helm_additional_values),
     yamlencode(local.helm_additional_values)
   ]
 }

--- a/massdriver-application-helm/variables.tf
+++ b/massdriver-application-helm/variables.tf
@@ -19,6 +19,12 @@ variable "chart" {
   type        = string
 }
 
+variable "helm_additional_values" {
+  description = "Additional helm values to set"
+  type = map
+  default = {}
+}
+
 variable "additional_envs" {
   description = "Additional environment variables to set"
   type        = list(


### PR DESCRIPTION
Added a variable to be able to pass additional helm values in as a module parameter. This is needed in the elasticsearch curator to get elasticsearch config in. [Usage](https://github.com/massdriver-cloud/application-examples/pull/29/files#diff-7c3b307cfceeb9e985bb5cd8797acf7e983a27852d26753d3be5baf0077b708dR9-R11).