### PR TITLE
Allowing null CIDRs

### DIFF
--- a/massdriver-application-azure-app-service/_variables.tf
+++ b/massdriver-application-azure-app-service/_variables.tf
@@ -44,10 +44,7 @@ variable "virtual_network_id" {
 }
 
 variable "network" {
-  type = object({
-    auto = bool
-    cidr = string
-  })
+  type = any
 }
 
 variable "monitoring" {


### PR DESCRIPTION
Workaround for required CIDR even if `auto` CIDR is enabled