### PR TITLE
migrate to new k8s_sa and token api

### DIFF
--- a/gcp-gke-core-services/README.md
+++ b/gcp-gke-core-services/README.md
@@ -36,11 +36,11 @@
 |------|------|
 | [kubernetes_cluster_role_binding.massdriver-cloud-provisioner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/cluster_role_binding) | resource |
 | [kubernetes_daemonset.nvidia_driver](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/daemonset) | resource |
-| [kubernetes_service_account.massdriver-cloud-provisioner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
+| [kubernetes_secret_v1.main](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret_v1) | resource |
+| [kubernetes_service_account_v1.cloud_provisioner](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account_v1) | resource |
 | [google_client_config.provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 | [google_container_cluster.cluster](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/container_cluster) | data source |
 | [google_dns_managed_zone.hosted_zones](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/dns_managed_zone) | data source |
-| [kubernetes_secret.massdriver-cloud-provisioner_service-account_secret](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/secret) | data source |
 
 ## Inputs
 

--- a/gcp-gke-core-services/outputs.tf
+++ b/gcp-gke-core-services/outputs.tf
@@ -1,4 +1,4 @@
 output "kubernetes_token" {
-  value     = lookup(data.kubernetes_secret.massdriver-cloud-provisioner_service-account_secret.data, "token")
+  value     = lookup(kubernetes_secret_v1.main.data, "token")
   sensitive = true
 }

--- a/gcp-gke-core-services/service_account.tf
+++ b/gcp-gke-core-services/service_account.tf
@@ -1,8 +1,18 @@
-resource "kubernetes_service_account" "massdriver-cloud-provisioner" {
+resource "kubernetes_service_account_v1" "cloud_provisioner" {
   metadata {
     name   = "massdriver-cloud-provisioner"
     labels = var.md_metadata.default_tags
   }
+}
+
+resource "kubernetes_secret_v1" "main" {
+  metadata {
+    name = "massdriver-cloud-provisioner"
+    annotations = {
+      "kubernetes.io/service-account.name" = kubernetes_service_account_v1.cloud_provisioner.metadata.0.name
+    }
+  }
+  type = "kubernetes.io/service-account-token"
 }
 
 resource "kubernetes_cluster_role_binding" "massdriver-cloud-provisioner" {
@@ -17,14 +27,7 @@ resource "kubernetes_cluster_role_binding" "massdriver-cloud-provisioner" {
   }
   subject {
     kind      = "ServiceAccount"
-    name      = kubernetes_service_account.massdriver-cloud-provisioner.metadata.0.name
-    namespace = kubernetes_service_account.massdriver-cloud-provisioner.metadata.0.namespace
-  }
-}
-
-data "kubernetes_secret" "massdriver-cloud-provisioner_service-account_secret" {
-  metadata {
-    name   = kubernetes_service_account.massdriver-cloud-provisioner.default_secret_name
-    labels = var.md_metadata.default_tags
+    name      = kubernetes_service_account_v1.cloud_provisioner.metadata.0.name
+    namespace = kubernetes_service_account_v1.cloud_provisioner.metadata.0.namespace
   }
 }


### PR DESCRIPTION
This isn't gke-specific and should be moved to a shared k8s module. 
https://linear.app/massdriver/issue/ORC-159/create-tf-module-to-share-k8s-service-account-and-token-creation