### PR TITLE
massdriver-application Managed Identity changes

### DIFF
--- a/massdriver-application-helm/README.md
+++ b/massdriver-application-helm/README.md
@@ -42,7 +42,7 @@ No requirements.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_application"></a> [application](#module\_application) | github.com/massdriver-cloud/terraform-modules//massdriver-application | 4270f29 |
-| <a name="module_massdriver_helm_values"></a> [massdriver\_helm\_values](#module\_massdriver\_helm\_values) | github.com/massdriver-cloud/terraform-modules//massdriver-helm-values | n/a |
+| <a name="module_massdriver_helm_values"></a> [massdriver\_helm\_values](#module\_massdriver\_helm\_values) | github.com/massdriver-cloud/terraform-modules//massdriver-helm-values | 4b8d47a |
 
 ## Resources
 

--- a/massdriver-application-helm/README.md
+++ b/massdriver-application-helm/README.md
@@ -35,13 +35,13 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | n/a |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.8.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_application"></a> [application](#module\_application) | github.com/massdriver-cloud/terraform-modules//massdriver-application | n/a |
+| <a name="module_application"></a> [application](#module\_application) | github.com/massdriver-cloud/terraform-modules//massdriver-application | 4270f29 |
 | <a name="module_massdriver_helm_values"></a> [massdriver\_helm\_values](#module\_massdriver\_helm\_values) | github.com/massdriver-cloud/terraform-modules//massdriver-helm-values | n/a |
 
 ## Resources
@@ -58,8 +58,10 @@ No requirements.
 | <a name="input_chart"></a> [chart](#input\_chart) | The path to your Helm chart | `string` | n/a | yes |
 | <a name="input_helm_additional_values"></a> [helm\_additional\_values](#input\_helm\_additional\_values) | Additional helm values to set | `map(any)` | `{}` | no |
 | <a name="input_kubernetes_cluster"></a> [kubernetes\_cluster](#input\_kubernetes\_cluster) | Massdriver Kubernetes Cluster Artifact | `any` | n/a | yes |
+| <a name="input_location"></a> [location](#input\_location) | Azure only, the location of the resource group. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | The release name of the chart, this should be your var.md\_metadata.name\_prefix | `string` | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace to deploy chart into | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Azure only, the name of resource group to create the Managed Identity in. | `string` | `null` | no |
 
 ## Outputs
 

--- a/massdriver-application-helm/helm_values.tf
+++ b/massdriver-application-helm/helm_values.tf
@@ -19,6 +19,6 @@ locals {
 }
 
 module "massdriver_helm_values" {
-  source                 = "github.com/massdriver-cloud/terraform-modules//massdriver-helm-values"
+  source                 = "github.com/massdriver-cloud/terraform-modules//massdriver-helm-values?ref=4b8d47a"
   massdriver_application = module.application
 }

--- a/massdriver-application-helm/main.tf
+++ b/massdriver-application-helm/main.tf
@@ -14,8 +14,8 @@ module "application" {
   kubernetes = {
     namespace        = var.namespace
     cluster_artifact = var.kubernetes_cluster
+    oidc_issuer_url  = try(var.kubernetes_cluster.data.infrastructure.oidc_issuer_url, null)
   }
-
   resource_group_name = var.resource_group_name
   location            = var.location
 }

--- a/massdriver-application-helm/main.tf
+++ b/massdriver-application-helm/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 module "application" {
-  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application"
+  source  = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=4270f29"
   name    = var.name
   service = "kubernetes"
 
@@ -15,6 +15,9 @@ module "application" {
     namespace        = var.namespace
     cluster_artifact = var.kubernetes_cluster
   }
+
+  resource_group_name = var.resource_group_name
+  location            = var.location
 }
 
 resource "helm_release" "application" {

--- a/massdriver-application-helm/variables.tf
+++ b/massdriver-application-helm/variables.tf
@@ -35,3 +35,15 @@ variable "additional_envs" {
   )
   default = []
 }
+
+variable "resource_group_name" {
+  description = "Azure only, the name of resource group to create the Managed Identity in."
+  type        = string
+  default     = null
+}
+
+variable "location" {
+  description = "Azure only, the location of the resource group."
+  type        = string
+  default     = null
+}

--- a/massdriver-application/README.md
+++ b/massdriver-application/README.md
@@ -43,14 +43,14 @@ module "application" {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_mdxc"></a> [mdxc](#requirement\_mdxc) | >= 0.1.0 |
+| <a name="requirement_mdxc"></a> [mdxc](#requirement\_mdxc) | >= 0.10.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_jq"></a> [jq](#provider\_jq) | 0.2.1 |
-| <a name="provider_mdxc"></a> [mdxc](#provider\_mdxc) | 0.1.0 |
+| <a name="provider_mdxc"></a> [mdxc](#provider\_mdxc) | 0.10.3 |
 
 ## Modules
 

--- a/massdriver-application/README.md
+++ b/massdriver-application/README.md
@@ -41,14 +41,16 @@ module "application" {
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_mdxc"></a> [mdxc](#requirement\_mdxc) | >= 0.1.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_jq"></a> [jq](#provider\_jq) | 0.2.1 |
-| <a name="provider_mdxc"></a> [mdxc](#provider\_mdxc) | 0.0.9 |
+| <a name="provider_mdxc"></a> [mdxc](#provider\_mdxc) | 0.1.0 |
 
 ## Modules
 
@@ -68,10 +70,10 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_application_identity_id"></a> [application\_identity\_id](#input\_application\_identity\_id) | If an application identity already exists, you can specify it here to skip the process of creating a new application identity. | `string` | `null` | no |
-| <a name="input_create_application_identity"></a> [create\_application\_identity](#input\_create\_application\_identity) | If an application identity already exists, you can specify it here to skip the process of creating a new application identity. | `bool` | `true` | no |
-| <a name="input_kubernetes"></a> [kubernetes](#input\_kubernetes) | Kubernetes configuration for binding the application identity to k8s workload identity (GCP) or federated assume role (AWS). Required if service='kubernetes'. | <pre>object({<br>    # k8s namespace workload will run in<br>    namespace = string,<br>    # Massdriver connection artifact<br>    cluster_artifact = any<br>  })</pre> | `null` | no |
+| <a name="input_kubernetes"></a> [kubernetes](#input\_kubernetes) | Kubernetes configuration for binding the application identity to k8s workload identity (GCP) or federated assume role (AWS). Required if service='kubernetes'. | <pre>object({<br>    # k8s namespace workload will run in<br>    namespace = string,<br>    # Massdriver connection artifact<br>    cluster_artifact = any<br>    # Azure AKS cluster produces this URL, needed for Workload Identity<br>    oidc_issuer_url = optional(string, null)<br>  })</pre> | `null` | no |
+| <a name="input_location"></a> [location](#input\_location) | Azure only, the location of the resource group. | `string` | `null` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the application. This should be the Massdriver package name. var.md\_metadata.name\_prefix | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Azure only, the name of resource group to create the Managed Identity in. | `string` | `null` | no |
 | <a name="input_service"></a> [service](#input\_service) | The cloud service type that will run this workload. | `string` | n/a | yes |
 
 ## Outputs
@@ -79,8 +81,9 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_cloud"></a> [cloud](#output\_cloud) | The cloud provisioning executed in. |
-| <a name="output_envs"></a> [envs](#output\_envs) | The policies parsed from massdriver.yaml |
-| <a name="output_id"></a> [id](#output\_id) | Cloud ID for application IAM (AWS Role, GCP Service Account, Azure Service Account, etc) |
+| <a name="output_envs"></a> [envs](#output\_envs) | The environment (config & secrets) parsed from massdriver.yaml |
+| <a name="output_id"></a> [id](#output\_id) | Cloud ID for application IAM (AWS Role, GCP Service Account, Azure Managed Identity, etc) |
+| <a name="output_identity"></a> [identity](#output\_identity) | The full MDXC Cloud Identity object, for accessing additional values beyond the ID of the Identity. |
 | <a name="output_params"></a> [params](#output\_params) | Parameters provided to bundle. |
 | <a name="output_policies"></a> [policies](#output\_policies) | The policies parsed from massdriver.yaml |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/massdriver-application/azure_identity.tf
+++ b/massdriver-application/azure_identity.tf
@@ -1,15 +1,11 @@
 locals {
-  base_identity = {
+  azure_identity = {
     location            = var.location
     resource_group_name = var.resource_group_name
-    kubernetes          = {}
-  }
-
-  azure_identity = local.is_kubernetes ? merge(local.base_identity, {
-    kubernetes = {
+    kubernetes = local.is_kubernetes ? {
       namespace            = var.kubernetes.namespace
       service_account_name = var.name
       oidc_issuer_url      = var.kubernetes.oidc_issuer_url
-    }
-  }) : local.base_identity
+    } : {}
+  }
 }

--- a/massdriver-application/azure_identity.tf
+++ b/massdriver-application/azure_identity.tf
@@ -6,6 +6,6 @@ locals {
       namespace            = var.kubernetes.namespace
       service_account_name = var.name
       oidc_issuer_url      = var.kubernetes.oidc_issuer_url
-    } : {}
+    } : null
   }
 }

--- a/massdriver-application/azure_identity.tf
+++ b/massdriver-application/azure_identity.tf
@@ -1,6 +1,15 @@
-# TODO: Configure for azure.
-# This very well just might be {} since workload identity isnt generally available.
-
 locals {
-  azure_identity = {}
+  base_identity = {
+    location            = var.location
+    resource_group_name = var.resource_group_name
+    kubernetes          = {}
+  }
+
+  azure_identity = local.is_kubernetes ? merge(local.base_identity, {
+    kubernetes = {
+      namespace            = var.kubernetes.namespace
+      service_account_name = var.name
+      oidc_issuer_url      = var.kubernetes.oidc_issuer_url
+    }
+  }) : local.base_identity
 }

--- a/massdriver-application/main.tf
+++ b/massdriver-application/main.tf
@@ -17,36 +17,27 @@ locals {
     secrets     = local.secrets
   })
 
-  application_identity_id = var.create_application_identity ? mdxc_application_identity.main.0.id : var.application_identity_id
+  application_identity_id = mdxc_application_identity.main.id
 
   policies = { for p in local.app_policies_queries : p => jsondecode(data.jq_query.policies[p].result) }
 
   # env vars that have been resolved. additional vars may be added per cloud
   base_envs = { for k, v in local.app_envs_queries : k => jsondecode(data.jq_query.envs[k].result) }
-    
+
   # Auto generate ENV Vars for each secret
   envs_with_secrets = merge(local.base_envs, local.secrets)
-    
-  # Needed by Azure k8s until Workload Identity is out of preview.
-  azure_envs = (local.is_azure_k8s && mdxc_application_identity.main[0] != null) ? mdxc_application_identity.main[0].azure_application_identity : {}
-  azure_aks_envs = local.is_azure_k8s ? {
-    AZURE_TENANT_ID : local.azure_envs.application_id
-    AZURE_CLIENT_ID : local.azure_envs.service_principal_client_id
-    AZURE_CLIENT_SECRET : local.azure_envs.service_principal_secret
-  } : {}
 
   cloud_envs = {
-    azure = merge(local.envs_with_secrets, local.azure_aks_envs)
+    azure = local.envs_with_secrets
     aws   = local.envs_with_secrets
     gcp   = local.envs_with_secrets
   }
 
   envs = local.cloud_envs[data.mdxc_cloud.current.cloud]
 
-  is_aws       = data.mdxc_cloud.current.cloud == "aws"
-  is_azure     = data.mdxc_cloud.current.cloud == "azure"
-  is_azure_k8s = local.is_azure && local.is_kubernetes
-  is_gcp       = data.mdxc_cloud.current.cloud == "gcp"
+  is_aws   = data.mdxc_cloud.current.cloud == "aws"
+  is_azure = data.mdxc_cloud.current.cloud == "azure"
+  is_gcp   = data.mdxc_cloud.current.cloud == "gcp"
 
   is_function   = var.service == "function"
   is_vm         = var.service == "vm"
@@ -68,8 +59,7 @@ data "jq_query" "envs" {
 data "mdxc_cloud" "current" {}
 
 resource "mdxc_application_identity" "main" {
-  count = var.create_application_identity ? 1 : 0
-  name  = var.name
+  name = var.name
 
   gcp_configuration   = local.is_gcp ? local.gcp_identity : null
   azure_configuration = local.is_azure ? local.azure_identity : null

--- a/massdriver-application/main.tf
+++ b/massdriver-application/main.tf
@@ -27,8 +27,16 @@ locals {
   # Auto generate ENV Vars for each secret
   envs_with_secrets = merge(local.base_envs, local.secrets)
 
+  # App Serivce / Function App will auto-inject the secret, but still need these env-vars added.
+  # AKS auto-injects everything (we add the Client ID and Tenant ID as annotations).
+  # I don't think having these added to all runtimes will hurt Workload Identity or other auth solutions.
+  azure_envs = {
+    AZURE_CLIENT_ID = mdxc_application_identity.main.azure_application_identity.client_id
+    AZURE_TENANT_ID = mdxc_application_identity.main.azure_application_identity.tenant_id
+  }
+
   cloud_envs = {
-    azure = local.envs_with_secrets
+    azure = merge(local.azure_envs, local.envs_with_secrets)
     aws   = local.envs_with_secrets
     gcp   = local.envs_with_secrets
   }

--- a/massdriver-application/outputs.tf
+++ b/massdriver-application/outputs.tf
@@ -9,7 +9,7 @@ output "policies" {
 }
 
 output "envs" {
-  sensitive = true
+  sensitive   = true
   description = "The environment (config & secrets) parsed from massdriver.yaml"
   value       = local.envs
 }
@@ -23,6 +23,11 @@ output "params" {
 }
 
 output "id" {
-  description = "Cloud ID for application IAM (AWS Role, GCP Service Account, Azure Service Account, etc)"
+  description = "Cloud ID for application IAM (AWS Role, GCP Service Account, Azure Managed Identity, etc)"
   value       = local.application_identity_id
+}
+
+output "identity" {
+  description = "The full MDXC Cloud Identity object, for accessing additional values beyond the ID of the Identity."
+  value       = mdxc_application_identity.main
 }

--- a/massdriver-application/outputs.tf
+++ b/massdriver-application/outputs.tf
@@ -30,4 +30,5 @@ output "id" {
 output "identity" {
   description = "The full MDXC Cloud Identity object, for accessing additional values beyond the ID of the Identity."
   value       = mdxc_application_identity.main
+  sensitive   = true
 }

--- a/massdriver-application/providers.tf
+++ b/massdriver-application/providers.tf
@@ -9,7 +9,8 @@ terraform {
     }
 
     mdxc = {
-      source = "massdriver-cloud/mdxc"
+      source  = "massdriver-cloud/mdxc"
+      version = ">= 0.1.0"
     }
   }
 }

--- a/massdriver-application/providers.tf
+++ b/massdriver-application/providers.tf
@@ -10,7 +10,7 @@ terraform {
 
     mdxc = {
       source  = "massdriver-cloud/mdxc"
-      version = ">= 0.1.0"
+      version = ">= 0.10.3"
     }
   }
 }

--- a/massdriver-application/variables.tf
+++ b/massdriver-application/variables.tf
@@ -21,17 +21,19 @@ variable "kubernetes" {
     namespace = string,
     # Massdriver connection artifact
     cluster_artifact = any
+    # Azure AKS cluster produces this URL, needed for Workload Identity
+    oidc_issuer_url = optional(string, null)
   })
 }
 
-variable "create_application_identity" {
-  description = "If an application identity already exists, you can specify it here to skip the process of creating a new application identity."
-  type        = bool
-  default     = true
+variable "resource_group_name" {
+  description = "Azure only, the name of resource group to create the Managed Identity in."
+  type        = string
+  default     = null
 }
 
-variable "application_identity_id" {
-  description = "If an application identity already exists, you can specify it here to skip the process of creating a new application identity."
+variable "location" {
+  description = "Azure only, the location of the resource group."
   type        = string
   default     = null
 }

--- a/massdriver-helm-values/service_account.tf
+++ b/massdriver-helm-values/service_account.tf
@@ -11,8 +11,15 @@ locals {
     }
   }
 
-  # TODO: Azure doesn't support WI yet, so not annotations to add
-  azure_service_account = {}
+  azure_service_account = {
+    labels = {
+      "azure.workload.identity/use" = "true"
+    }
+    annotations = {
+      "azure.workload.identity/client-id" = var.massdriver_application.identity.azure_application_identity.client_id
+      "azure.workload.identity/tenant-id" = var.massdriver_application.identity.azure_application_identity.tenant_id
+    }
+  }
 
   cloud_service_accounts = {
     aws   = local.aws_service_account,


### PR DESCRIPTION
Terraform changes needed to support [MDXC Managed Identities](https://github.com/massdriver-cloud/terraform-provider-mdxc/pull/32)

Tested in my personal org. My personal `azure-storage-account-application-assets` bundle produces an artifact with the `Storage Contributor` role for the `edit` policy. I did that until we merge [this](https://github.com/massdriver-cloud/artifact-definitions/pull/144) change to the Azure iam security block in `artifact-definitions`.

<img width="889" alt="Screenshot 2023-01-28 at 11 38 36 PM" src="https://user-images.githubusercontent.com/651833/215312333-a3ea508b-9e2f-44a6-b760-7c25ef61f8c4.png">

- [x] verified on AKS - https://aks-app-000.mdazuresbx.com/
- [x] verified on App Service  - https://app-service-001.mdazuresbx.com/
- [x] verified on Function App - https://function-app-003.mdazuresbx.com/
- [x] verified on VMs - https://vm-000.mdazuresbx.com/
- [x] poor-mans round-robin service for all 4 - https://bloby.mdazuresbx.com/

closes: https://linear.app/massdriver/issue/ORC-198/add-annotations-and-labels-to-terraform-modules