### PR TITLE
Adding repo/version to support using repo helm charts.

### DIFF
--- a/massdriver-application-helm/main.tf
+++ b/massdriver-application-helm/main.tf
@@ -16,8 +16,8 @@ module "application" {
 resource "helm_release" "application" {
   name              = var.name
   chart             = var.chart
-  repository        = var.repository
-  version           = var.version
+  repository        = var.helm_repository
+  version           = var.helm_version
   namespace         = var.namespace
   create_namespace  = true
   force_update      = true

--- a/massdriver-application-helm/main.tf
+++ b/massdriver-application-helm/main.tf
@@ -16,6 +16,8 @@ module "application" {
 resource "helm_release" "application" {
   name              = var.name
   chart             = var.chart
+  repository        = var.repository
+  version           = var.version
   namespace         = var.namespace
   create_namespace  = true
   force_update      = true

--- a/massdriver-application-helm/variables.tf
+++ b/massdriver-application-helm/variables.tf
@@ -19,13 +19,13 @@ variable "chart" {
   type        = string
 }
 
-variable "version" {
+variable "helm_version" {
   description = "(Optional) The helm chart version. Required when not using a local chart."
   type        = string
   default     = null
 }
 
-variable "repository" {
+variable "helm_repository" {
   description = "(Optional) The chart's helm repository. Required when not using a local chart."
   type        = string
   default     = null

--- a/massdriver-application-helm/variables.tf
+++ b/massdriver-application-helm/variables.tf
@@ -19,6 +19,18 @@ variable "chart" {
   type        = string
 }
 
+variable "version" {
+  description = "(Optional) The helm chart version. Required when not using a local chart."
+  type        = string
+  default     = null
+}
+
+variable "repository" {
+  description = "(Optional) The chart's helm repository. Required when not using a local chart."
+  type        = string
+  default     = null
+}
+
 variable "helm_additional_values" {
   description = "Additional helm values to set"
   type        = map(any)


### PR DESCRIPTION
This allows us to set repository's for charts. We are using this so we can publish generic framework and language charts (non-md users) and then using them from our templates (md users)