### PR TITLE
Add ECS support to the 'service' variable of application template

### DIFF
--- a/massdriver-application/README.md
+++ b/massdriver-application/README.md
@@ -49,8 +49,8 @@ module "application" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_jq"></a> [jq](#provider\_jq) | n/a |
-| <a name="provider_mdxc"></a> [mdxc](#provider\_mdxc) | >= 0.10.3 |
+| <a name="provider_jq"></a> [jq](#provider\_jq) | 0.2.1 |
+| <a name="provider_mdxc"></a> [mdxc](#provider\_mdxc) | 0.10.3 |
 
 ## Modules
 

--- a/massdriver-application/aws_identity.tf
+++ b/massdriver-application/aws_identity.tf
@@ -1,6 +1,7 @@
 locals {
   aws_service_map = {
     function   = "lambda",
+    container  = "ecs-tasks"
     vm         = "ec2",
     kubernetes = "eks"
   }
@@ -27,6 +28,11 @@ locals {
         "Service": [
           "${local.aws_service}.amazonaws.com"
         ]
+      }
+      "Condition":{
+        "StringEquals":{
+          "aws:SourceAccount": "${data.mdxc_cloud.current.id}"
+        }
       }
     }
   ]

--- a/massdriver-application/aws_identity.tf
+++ b/massdriver-application/aws_identity.tf
@@ -28,7 +28,7 @@ locals {
         "Service": [
           "${local.aws_service}.amazonaws.com"
         ]
-      }
+      },
       "Condition":{
         "StringEquals":{
           "aws:SourceAccount": "${data.mdxc_cloud.current.id}"

--- a/massdriver-application/main.tf
+++ b/massdriver-application/main.tf
@@ -30,6 +30,7 @@ locals {
   is_gcp   = data.mdxc_cloud.current.cloud == "gcp"
 
   is_function   = var.service == "function"
+  is_container  = var.service == "container"
   is_vm         = var.service == "vm"
   is_kubernetes = var.service == "kubernetes"
 }

--- a/massdriver-application/variables.tf
+++ b/massdriver-application/variables.tf
@@ -8,8 +8,8 @@ variable "service" {
   type        = string
 
   validation {
-    condition     = contains(["function", "vm", "kubernetes"], var.service)
-    error_message = "Allowed values for service are \"function\", \"vm\", or \"kubernetes\"."
+    condition     = contains(["function", "container", "vm", "kubernetes"], var.service)
+    error_message = "Allowed values for service are \"function\", \"container\", \"vm\", or \"kubernetes\"."
   }
 }
 


### PR DESCRIPTION
AWS ECS tasks need a custom trust policy that isn't covered by our existing `service` types. I added a new one `container`.

I don't really like this change. I couldn't think of a good name ("container", or "serverless_container" or "container_runtime"), but more importantly, it seems like this "service" abstraction is starting to pull at the seems a bit for a two reasons:
* AWS is the only cloud where the `service` field makes any difference, aside from `kubernetes`. And its only for the role trust policy.
* Kubernetes is already covered by its own block

Thus we seem to be stuck maintaining this abstraction purely for AWS. I'm thinking we can move this logic into the `mdxc` provider under the `aws` block, and deprecate the `service` field at the top-level. Then, in the `aws_configuration` block, we can have 2 mutually-exclusive fields: `service` and `assume_role_policy`. This allows us to just have `ec2`, `ecs`, `eks` and `lambda` as "auto-generated" role types where we generate the assume-role policy in the MDXC provider code. Or, the user can take the reins and specify the assume-role policy themselves if our generated policy doesn't work for them.

I would make this ^ change, but I want to get consensus on it first before making the change, and this current PR is the fastest way to unblock ECS.