### PR TITLE
Removing map(any) for map

### DIFF
--- a/massdriver-application-helm/variables.tf
+++ b/massdriver-application-helm/variables.tf
@@ -33,7 +33,7 @@ variable "helm_repository" {
 
 variable "helm_additional_values" {
   description = "Additional helm values to set"
-  type        = map(any)
+  type        = any
   default     = {}
 }
 


### PR DESCRIPTION
This is a unstructured map ... `map(any)` doesn't mean the value can by literally anything, it can be _any_ type. If you pass in:

```hcl
helm_additional_values = {
name = "foo"
command = ["/bin/sh"]
}
```

It will fail because the value's types don't match.

See [here](https://developer.hashicorp.com/terraform/language/expressions/type-constraints#map)