### PR TITLE
Adding storage feature support

### DIFF
--- a/azure/storage-account/README.md
+++ b/azure/storage-account/README.md
@@ -24,10 +24,14 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_tier"></a> [access\_tier](#input\_access\_tier) | n/a | `string` | n/a | yes |
+| <a name="input_blob_properties"></a> [blob\_properties](#input\_blob\_properties) | n/a | <pre>object({<br>    delete_retention_policy           = optional(number)<br>    container_delete_retention_policy = optional(number)<br>  })</pre> | n/a | yes |
+| <a name="input_enable_blob"></a> [enable\_blob](#input\_enable\_blob) | n/a | `bool` | `false` | no |
 | <a name="input_enable_data_lake"></a> [enable\_data\_lake](#input\_enable\_data\_lake) | n/a | `bool` | `false` | no |
+| <a name="input_enable_queue"></a> [enable\_queue](#input\_enable\_queue) | n/a | `bool` | `false` | no |
 | <a name="input_kind"></a> [kind](#input\_kind) | n/a | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
+| <a name="input_queue_properties"></a> [queue\_properties](#input\_queue\_properties) | n/a | <pre>object({<br>    logging = object({<br>      delete                = optional(bool)<br>      read                  = optional(bool)<br>      write                 = optional(bool)<br>      version               = optional(string)<br>      retention_policy_days = optional(number)<br>    })<br>  })</pre> | n/a | yes |
 | <a name="input_replication_type"></a> [replication\_type](#input\_replication\_type) | n/a | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | n/a | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `any` | n/a | yes |

--- a/azure/storage-account/README.md
+++ b/azure/storage-account/README.md
@@ -24,14 +24,12 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_tier"></a> [access\_tier](#input\_access\_tier) | n/a | `string` | n/a | yes |
-| <a name="input_blob_properties"></a> [blob\_properties](#input\_blob\_properties) | n/a | <pre>object({<br>    delete_retention_policy           = optional(number)<br>    container_delete_retention_policy = optional(number)<br>  })</pre> | n/a | yes |
-| <a name="input_enable_blob"></a> [enable\_blob](#input\_enable\_blob) | n/a | `bool` | `false` | no |
+| <a name="input_blob_properties"></a> [blob\_properties](#input\_blob\_properties) | n/a | <pre>object({<br>    delete_retention_policy           = optional(number)<br>    container_delete_retention_policy = optional(number)<br>  })</pre> | `null` | no |
 | <a name="input_enable_data_lake"></a> [enable\_data\_lake](#input\_enable\_data\_lake) | n/a | `bool` | `false` | no |
-| <a name="input_enable_queue"></a> [enable\_queue](#input\_enable\_queue) | n/a | `bool` | `false` | no |
 | <a name="input_kind"></a> [kind](#input\_kind) | n/a | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | n/a | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | n/a | yes |
-| <a name="input_queue_properties"></a> [queue\_properties](#input\_queue\_properties) | n/a | <pre>object({<br>    logging = object({<br>      delete                = optional(bool)<br>      read                  = optional(bool)<br>      write                 = optional(bool)<br>      version               = optional(string)<br>      retention_policy_days = optional(number)<br>    })<br>  })</pre> | n/a | yes |
+| <a name="input_queue_properties"></a> [queue\_properties](#input\_queue\_properties) | n/a | <pre>object({<br>    logging = object({<br>      delete                = optional(bool)<br>      read                  = optional(bool)<br>      write                 = optional(bool)<br>      version               = optional(string)<br>      retention_policy_days = optional(number)<br>    })<br>  })</pre> | `null` | no |
 | <a name="input_replication_type"></a> [replication\_type](#input\_replication\_type) | n/a | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | n/a | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `any` | n/a | yes |

--- a/azure/storage-account/main.tf
+++ b/azure/storage-account/main.tf
@@ -17,9 +17,8 @@ resource "azurerm_storage_account" "main" {
   is_hns_enabled                = var.enable_data_lake
   tags                          = var.tags
 
-  # This is a recommendation from BridgeCrew to enable queue logging for storage accounts.
   dynamic "queue_properties" {
-    for_each = var.enable_queue ? [1] : []
+    for_each = var.queue_properties != null ? toset(["true"]) : toset([])
     content {
       logging {
         delete                = var.queue_properties.logging.delete
@@ -32,7 +31,7 @@ resource "azurerm_storage_account" "main" {
   }
 
   dynamic "blob_properties" {
-    for_each = var.enable_blob ? [1] : []
+    for_each = var.blob_properties != null ? toset(["true"]) : toset([])
     content {
       delete_retention_policy {
         days = var.blob_properties.delete_retention_policy

--- a/azure/storage-account/main.tf
+++ b/azure/storage-account/main.tf
@@ -18,13 +18,28 @@ resource "azurerm_storage_account" "main" {
   tags                          = var.tags
 
   # This is a recommendation from BridgeCrew to enable queue logging for storage accounts.
-  queue_properties {
-    logging {
-      delete                = true
-      read                  = true
-      write                 = true
-      version               = "1.0"
-      retention_policy_days = 10
+  dynamic "queue_properties" {
+    for_each = var.enable_queue ? [1] : []
+    content {
+      logging {
+        delete                = var.queue_properties.logging.delete
+        read                  = var.queue_properties.logging.read
+        write                 = var.queue_properties.logging.write
+        version               = var.queue_properties.logging.version
+        retention_policy_days = var.queue_properties.logging.retention_policy_days
+      }
+    }
+  }
+
+  dynamic "blob_properties" {
+    for_each = var.enable_blob ? [1] : []
+    content {
+      delete_retention_policy {
+        days = var.blob_properties.delete_retention_policy
+      }
+      container_delete_retention_policy {
+        days = var.blob_properties.container_delete_retention_policy
+      }
     }
   }
 

--- a/azure/storage-account/variables.tf
+++ b/azure/storage-account/variables.tf
@@ -51,21 +51,12 @@ variable "enable_data_lake" {
   default = false
 }
 
-variable "enable_queue" {
-  type    = bool
-  default = false
-}
-
-variable "enable_blob" {
-  type    = bool
-  default = false
-}
-
 variable "blob_properties" {
   type = object({
     delete_retention_policy           = optional(number)
     container_delete_retention_policy = optional(number)
   })
+  default = null
 }
 
 variable "queue_properties" {
@@ -78,6 +69,7 @@ variable "queue_properties" {
       retention_policy_days = optional(number)
     })
   })
+  default = null
 }
 
 variable "tags" {

--- a/azure/storage-account/variables.tf
+++ b/azure/storage-account/variables.tf
@@ -51,6 +51,35 @@ variable "enable_data_lake" {
   default = false
 }
 
+variable "enable_queue" {
+  type    = bool
+  default = false
+}
+
+variable "enable_blob" {
+  type    = bool
+  default = false
+}
+
+variable "blob_properties" {
+  type = object({
+    delete_retention_policy           = optional(number)
+    container_delete_retention_policy = optional(number)
+  })
+}
+
+variable "queue_properties" {
+  type = object({
+    logging = object({
+      delete                = optional(bool)
+      read                  = optional(bool)
+      write                 = optional(bool)
+      version               = optional(string)
+      retention_policy_days = optional(number)
+    })
+  })
+}
+
 variable "tags" {
   type = any
 }


### PR DESCRIPTION
Adding support for premium storage accounts (that do not allow queue_properties to deploy). Premium storage is excellent for low latency/high bandwidth/high transaction rate types of storage. Ideal scenarios include AI/ML storage.

Tested locally w/ azure data lake storage bundle