### PR TITLE
Remove broken alarm

### DIFF
--- a/massdriver-application-azure-app-service/README.md
+++ b/massdriver-application-azure-app-service/README.md
@@ -21,7 +21,6 @@
 | <a name="module_dns"></a> [dns](#module\_dns) | github.com/massdriver-cloud/terraform-modules//azure/dns | 9df7459 |
 | <a name="module_http_4xx_metric_alert"></a> [http\_4xx\_metric\_alert](#module\_http\_4xx\_metric\_alert) | github.com/massdriver-cloud/terraform-modules//azure-monitor-metrics-alarm | 40d6e54 |
 | <a name="module_http_5xx_metric_alert"></a> [http\_5xx\_metric\_alert](#module\_http\_5xx\_metric\_alert) | github.com/massdriver-cloud/terraform-modules//azure-monitor-metrics-alarm | 40d6e54 |
-| <a name="module_response_metric_alert"></a> [response\_metric\_alert](#module\_response\_metric\_alert) | github.com/massdriver-cloud/terraform-modules//azure-monitor-metrics-alarm | 40d6e54 |
 
 ## Resources
 

--- a/massdriver-application-azure-app-service/alarms.tf
+++ b/massdriver-application-azure-app-service/alarms.tf
@@ -1,13 +1,5 @@
 locals {
   automated_alarms = {
-    response_metric_alert = {
-      severity    = "1"
-      frequency   = "PT5M"
-      window_size = "PT5M"
-      operator    = "GreaterThan"
-      aggregation = "Average"
-      threshold   = 60
-    }
     http_4xx_metric_alert = {
       severity    = "1"
       frequency   = "PT5M"
@@ -37,32 +29,6 @@ module "alarm_channel" {
   source              = "github.com/massdriver-cloud/terraform-modules//azure-alarm-channel?ref=40d6e54"
   md_metadata         = var.md_metadata
   resource_group_name = azurerm_resource_group.main.name
-}
-
-module "response_metric_alert" {
-  count                   = lookup(local.alarms, "response_metric_alert", null) == null ? 0 : 1
-  source                  = "github.com/massdriver-cloud/terraform-modules//azure-monitor-metrics-alarm?ref=40d6e54"
-  scopes                  = [azurerm_linux_web_app.main.id]
-  resource_group_name     = azurerm_resource_group.main.name
-  monitor_action_group_id = module.alarm_channel.id
-  severity                = local.alarms.response_metric_alert.severity
-  frequency               = local.alarms.response_metric_alert.frequency
-  window_size             = local.alarms.response_metric_alert.window_size
-
-  depends_on = [
-    azurerm_linux_web_app.main
-  ]
-
-  md_metadata  = var.md_metadata
-  display_name = "Response Time"
-  message      = "High response time"
-
-  alarm_name       = "${var.name}-highResponseTime"
-  operator         = local.alarms.response_metric_alert.operator
-  metric_name      = "HttpResponseTime"
-  metric_namespace = "microsoft.web/sites"
-  aggregation      = local.alarms.response_metric_alert.aggregation
-  threshold        = local.alarms.response_metric_alert.threshold
 }
 
 module "http_4xx_metric_alert" {

--- a/massdriver-application-azure-app-service/auto-scaling.tf
+++ b/massdriver-application-azure-app-service/auto-scaling.tf
@@ -4,6 +4,7 @@ resource "azurerm_monitor_autoscale_setting" "main" {
   location            = azurerm_resource_group.main.location
   target_resource_id  = azurerm_service_plan.main.id
   enabled             = true
+  tags                = var.tags
 
   profile {
     name = "autoscale-profile"
@@ -62,5 +63,4 @@ resource "azurerm_monitor_autoscale_setting" "main" {
   depends_on = [
     azurerm_service_plan.main
   ]
-  tags = var.tags
 }

--- a/massdriver-application-azure-app-service/main.tf
+++ b/massdriver-application-azure-app-service/main.tf
@@ -24,11 +24,6 @@ resource "azurerm_service_plan" "main" {
 }
 
 locals {
-  # https://learn.microsoft.com/en-us/azure/app-service/reference-app-settings?tabs=kudu%2Cdotnet#custom-containers
-  service_settings = {
-    # DOCKER_ENABLE_CI = "true"
-  }
-
   # App Serivce will auto-inject the User-Assigned Identity secret, but still need these env-vars added.
   identity_envs = {
     AZURE_CLIENT_ID = module.application.identity.azure_application_identity.client_id
@@ -45,7 +40,7 @@ resource "azurerm_linux_web_app" "main" {
   tags                = var.tags
 
   # environment variables
-  app_settings = merge(local.service_settings, local.identity_envs, module.application.envs)
+  app_settings = merge(local.identity_envs, module.application.envs)
 
   identity {
     type = "UserAssigned"


### PR DESCRIPTION
This alarm, regardless of the configuration of the threshold, is constantly firing off. Looked at the metrics in the portal and it's consistently spiking, without traffic. I think we can remove this alarm for now as it's more of a headache than anything else.