### PR TITLE
feat(azure): allow cors_rule in azure_storage_account module

### DIFF
--- a/azure/storage-account/main.tf
+++ b/azure/storage-account/main.tf
@@ -39,6 +39,16 @@ resource "azurerm_storage_account" "main" {
       container_delete_retention_policy {
         days = var.blob_properties.container_delete_retention_policy
       }
+      dynamic "cors_rule" {
+        for_each = var.blob_properties.cors_rule
+        content {
+          allowed_headers    = cors_rule.value.allowed_headers
+          allowed_methods    = cors_rule.value.allowed_methods
+          allowed_origins    = cors_rule.value.allowed_origins
+          exposed_headers    = cors_rule.value.exposed_headers
+          max_age_in_seconds = cors_rule.value.max_age_in_seconds
+        }
+      }
     }
   }
 

--- a/azure/storage-account/variables.tf
+++ b/azure/storage-account/variables.tf
@@ -55,6 +55,13 @@ variable "blob_properties" {
   type = object({
     delete_retention_policy           = optional(number)
     container_delete_retention_policy = optional(number)
+    cors_rule = optional(list(object({
+      allowed_headers    = list(string)
+      allowed_methods    = list(string)
+      allowed_origins    = list(string)
+      exposed_headers    = list(string)
+      max_age_in_seconds = number
+    })))
   })
   default = null
 }


### PR DESCRIPTION
Extends azure storage account module allowing to pass cors_rule (optional, array).