### PR TITLE
Bumping version to support k8s v1.26

### DIFF
--- a/k8s-ingress-nginx/README.md
+++ b/k8s-ingress-nginx/README.md
@@ -9,7 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | n/a |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.10.1 |
 
 ## Modules
 

--- a/k8s-ingress-nginx/main.tf
+++ b/k8s-ingress-nginx/main.tf
@@ -21,7 +21,7 @@ resource "helm_release" "ingress-nginx" {
   name             = var.release
   chart            = "ingress-nginx"
   repository       = "https://kubernetes.github.io/ingress-nginx"
-  version          = "4.0.17"
+  version          = "4.7.0"
   namespace        = var.namespace
   create_namespace = true
   wait_for_jobs    = true


### PR DESCRIPTION
Tested w/ local deployment by deploying/decomming AKS bundle using v1.26, 1.25, and 1.24