### PR TITLE
Updating autoheal rule via Azure recommendation

### DIFF
--- a/massdriver-application-azure-app-service/main.tf
+++ b/massdriver-application-azure-app-service/main.tf
@@ -81,17 +81,13 @@ resource "azurerm_linux_web_app" "main" {
         action_type = "Recycle"
       }
       trigger {
-        requests {
-          count    = 5
-          interval = "00:01:00"
-        }
         slow_request {
-          count      = 5
-          interval   = "00:01:00"
-          time_taken = "00:00:10"
+          count      = 100
+          interval   = "00:05:00"
+          time_taken = "00:00:30"
         }
         status_code {
-          count             = 5
+          count             = 10
           interval          = "00:01:00"
           status_code_range = "400-510"
         }


### PR DESCRIPTION
Azure app service recommendation stating this rule is too restrictive and should be updated to the values set to reduce potential downtime of app being recycled too frequently.