### PR TITLE
Adds the ability to pass additional values on to `external-dns`

### DIFF
--- a/k8s-external-dns-aws/_variables.tf
+++ b/k8s-external-dns-aws/_variables.tf
@@ -23,3 +23,10 @@ variable "route53_hosted_zones" {
   type        = map(string)
   default     = {}
 }
+
+variable "helm_additional_values" {
+  type        = any
+  description = "a map of helm variables (key) to their values, used for setting anything in values.yaml"
+  default     = {}
+}
+

--- a/k8s-external-dns-aws/main.tf
+++ b/k8s-external-dns-aws/main.tf
@@ -11,6 +11,7 @@ module "external-dns" {
         "eks.amazonaws.com/role-arn" = aws_iam_role.external-dns.arn
       }
     }
+    yamlencode(var.helm_additional_values)
   }
   dns_provider = "aws"
 }

--- a/k8s-external-dns-aws/main.tf
+++ b/k8s-external-dns-aws/main.tf
@@ -5,13 +5,12 @@ module "external-dns" {
   release            = var.release
   namespace          = var.namespace
   domain_filters     = join(",", concat([for zone, name in var.route53_hosted_zones : name], []))
-  helm_additional_values = {
+  helm_additional_values = merge({
     serviceAccount = {
       annotations = {
         "eks.amazonaws.com/role-arn" = aws_iam_role.external-dns.arn
       }
     }
-    yamlencode(var.helm_additional_values)
-  }
+  }, var.helm_additional_values)
   dns_provider = "aws"
 }


### PR DESCRIPTION
This is needed to enable providing `txtPrefix` and `txtSuffix` for configurations that need control of this value as documented in massdriver-cloud/aws-eks-cluster#55.