### PR TITLE
Update to Azure/GCP app identity, azure app service docker, and azure app service app insights

### DIFF
--- a/massdriver-application-azure-app-service/_variables.tf
+++ b/massdriver-application-azure-app-service/_variables.tf
@@ -15,6 +15,8 @@ variable "image" {
     registry = string
     name     = string
     tag      = string
+    username = optional(string)
+    password = optional(string)
   })
 }
 

--- a/massdriver-application-azure-app-service/alarms.tf
+++ b/massdriver-application-azure-app-service/alarms.tf
@@ -26,10 +26,20 @@ locals {
   monitoring_enabled = var.monitoring.mode != "DISABLED" ? 1 : 0
 }
 
+resource "azurerm_log_analytics_workspace" "main" {
+  name                = var.name
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+  tags                = var.tags
+}
+
 resource "azurerm_application_insights" "main" {
   name                = var.name
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
+  workspace_id        = azurerm_log_analytics_workspace.main.id
   application_type    = "other"
   tags                = var.tags
 }

--- a/massdriver-application-azure-app-service/main.tf
+++ b/massdriver-application-azure-app-service/main.tf
@@ -1,3 +1,7 @@
+locals {
+  docker_registry_url = strcontains(var.image.name, "azurecr.io") ? "https://mcr.microsoft.com" : "https://index.docker.io"
+}
+
 module "application" {
   source              = "github.com/massdriver-cloud/terraform-modules//massdriver-application?ref=61a38e9"
   name                = var.name
@@ -95,10 +99,8 @@ resource "azurerm_linux_web_app" "main" {
     }
 
     application_stack {
-      docker_registry_url      = var.image.registry
-      docker_image_name        = "${var.image.name}/${var.image.tag}"
-      docker_registry_username = var.image.username
-      docker_registry_password = var.image.password
+      docker_registry_url      = local.docker_registry_url
+      docker_image_name        = "${var.image.name}:${var.image.tag}"
     }
 
     app_command_line = var.command

--- a/massdriver-application-azure-app-service/main.tf
+++ b/massdriver-application-azure-app-service/main.tf
@@ -95,9 +95,10 @@ resource "azurerm_linux_web_app" "main" {
     }
 
     application_stack {
-      # configuring the structure this way so that the image block in massdriver.yaml is identical across azure runtimes
-      docker_image     = "${var.image.registry}/${var.image.name}"
-      docker_image_tag = var.image.tag
+      docker_registry_url      = var.image.registry
+      docker_image_name        = "${var.image.name}/${var.image.tag}"
+      docker_registry_username = var.image.username
+      docker_registry_password = var.image.password
     }
 
     app_command_line = var.command

--- a/massdriver-application/azure_identity.tf
+++ b/massdriver-application/azure_identity.tf
@@ -1,5 +1,5 @@
 locals {
-  azure_identity = {
+  azure_identity = local.is_azure ? {
     location            = var.location
     resource_group_name = var.resource_group_name
     kubernetes = local.is_kubernetes ? {
@@ -7,5 +7,5 @@ locals {
       service_account_name = var.name
       oidc_issuer_url      = var.kubernetes.cluster_artifact.data.infrastructure.oidc_issuer_url
     } : null
-  }
+  } : null
 }

--- a/massdriver-application/gcp_identity.tf
+++ b/massdriver-application/gcp_identity.tf
@@ -3,10 +3,10 @@
 # namespace and k8s service account name
 
 locals {
-  gcp_identity = local.is_gcp && local.is_kubernetes ? {
-    kubernetes = {
+  gcp_identity = local.is_gcp ? {
+    kubernetes = local.is_kubernetes ? {
       namespace            = var.kubernetes.namespace
       service_account_name = var.name
-    }
-  } : {}
+    } : null
+  } : null
 }

--- a/massdriver-application/gcp_identity.tf
+++ b/massdriver-application/gcp_identity.tf
@@ -3,7 +3,7 @@
 # namespace and k8s service account name
 
 locals {
-  gcp_identity = local.is_kubernetes ? {
+  gcp_identity = local.is_gcp && local.is_kubernetes ? {
     kubernetes = {
       namespace            = var.kubernetes.namespace
       service_account_name = var.name


### PR DESCRIPTION
Thoroughly tested in local setting for each of these changes.

- Update to Azure/GCP identity blocks due to OIDC being forced for k8s app template, but not supported by GCP.
- Update to Azure app service Docker fields due to deprecation of older fields/format (update to app template coming today too)
- Update to Azure app service application insights: app insights classic mode being retired, log analytics workspace now required for app insights