### PR TITLE
Workload Identity support for AKS External DNS

### DIFF
--- a/k8s-external-dns-azure/README.md
+++ b/k8s-external-dns-azure/README.md
@@ -9,9 +9,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | n/a |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.90.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.25.2 |
 
 ## Modules
 
@@ -23,12 +22,12 @@ No requirements.
 
 | Name | Type |
 |------|------|
-| [azuread_application.external_dns](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
-| [azuread_service_principal.external_dns](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
-| [azuread_service_principal_password.external_dns](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal_password) | resource |
+| [azurerm_federated_identity_credential.external_dns](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
 | [azurerm_role_assignment.external_dns](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_user_assigned_identity.external_dns](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 | [kubernetes_secret.external_dns](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_resource_group.external_dns](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
 
 ## Inputs
 

--- a/k8s-external-dns-azure/iam.tf
+++ b/k8s-external-dns-azure/iam.tf
@@ -16,6 +16,7 @@ resource "azurerm_user_assigned_identity" "external_dns" {
   location            = data.azurerm_resource_group.external_dns.location
   name                = "${var.md_metadata.name_prefix}-externaldns"
   resource_group_name = data.azurerm_resource_group.external_dns.name
+  tags                = var.md_metadata.default_tags
 }
 
 resource "azurerm_federated_identity_credential" "external_dns" {

--- a/k8s-external-dns-azure/iam.tf
+++ b/k8s-external-dns-azure/iam.tf
@@ -1,30 +1,49 @@
 locals {
   # This needs to match the SA name in the submodule
   service_account_name = var.release == "external-dns" ? "external-dns" : "${var.release}-external-dns"
-  domain_filters       = join(",", tolist(var.azure_dns_zones.dns_zones))
+  # aks_oidc_short       = replace(var.kubernetes_cluster.data.infrastructure.oidc_issuer_url, "https://", "")
+  domain_filters = join(",", tolist(var.azure_dns_zones.dns_zones))
 }
 
 data "azurerm_client_config" "current" {
 }
 
 ## Azure AD application that represents the app
-resource "azuread_application" "external_dns" {
-  display_name = "${var.md_metadata.name_prefix}-externaldns"
+# resource "azuread_application" "external_dns" {
+#   display_name = "${var.md_metadata.name_prefix}-externaldns"
+# }
+
+# ## Azure AD app is required to create the service principal
+# resource "azuread_service_principal" "external_dns" {
+#   application_id = azuread_application.external_dns.application_id
+# }
+
+# resource "azuread_service_principal_password" "external_dns" {
+#   service_principal_id = azuread_service_principal.external_dns.id
+# }
+data "azurerm_resource_group" "external_dns" {
+  name = var.azure_dns_zones.resource_group
 }
 
-## Azure AD app is required to create the service principal
-resource "azuread_service_principal" "external_dns" {
-  application_id = azuread_application.external_dns.application_id
+resource "azurerm_user_assigned_identity" "external_dns" {
+  location            = data.azurerm_resource_group.external_dns.location
+  name                = var.md_metadata.name_prefix
+  resource_group_name = data.azurerm_resource_group.external_dns.name
 }
 
-resource "azuread_service_principal_password" "external_dns" {
-  service_principal_id = azuread_service_principal.external_dns.id
+resource "azurerm_federated_identity_credential" "external_dns" {
+  name                = var.md_metadata.name_prefix
+  resource_group_name = data.azurerm_resource_group.external_dns.name
+  audience            = ["api://AzureADTokenExchange"]
+  issuer              = var.kubernetes_cluster.data.infrastructure.oidc_issuer_url
+  parent_id           = azurerm_user_assigned_identity.external_dns.id
+  subject             = "system:serviceaccount:${var.namespace}:${local.service_account_name}"
 }
 
 resource "azurerm_role_assignment" "external_dns" {
   for_each             = toset(["Reader", "DNS Zone Contributor"])
   scope                = "/subscriptions/${data.azurerm_client_config.current.subscription_id}"
-  principal_id         = azuread_service_principal.external_dns.id
+  principal_id         = azurerm_user_assigned_identity.external_dns.principal_id
   role_definition_name = each.key
 }
 
@@ -36,11 +55,11 @@ resource "kubernetes_secret" "external_dns" {
   }
   data = {
     "azure.json" = jsonencode({
-      tenantId        = data.azurerm_client_config.current.tenant_id
-      subscriptionId  = data.azurerm_client_config.current.subscription_id
-      resourceGroup   = var.azure_dns_zones.resource_group
-      aadClientId     = azuread_service_principal.external_dns.application_id
-      aadClientSecret = azuread_service_principal_password.external_dns.value
+      tenantId                    = data.azurerm_client_config.current.tenant_id
+      subscriptionId              = data.azurerm_client_config.current.subscription_id
+      resourceGroup               = data.azurerm_resource_group.external_dns.name
+      userAssignedIdentityID      = azurerm_user_assigned_identity.external_dns.id
+      useManagedIdentityExtension = true
     })
   }
 }

--- a/k8s-external-dns-azure/iam.tf
+++ b/k8s-external-dns-azure/iam.tf
@@ -8,19 +8,6 @@ locals {
 data "azurerm_client_config" "current" {
 }
 
-## Azure AD application that represents the app
-# resource "azuread_application" "external_dns" {
-#   display_name = "${var.md_metadata.name_prefix}-externaldns"
-# }
-
-# ## Azure AD app is required to create the service principal
-# resource "azuread_service_principal" "external_dns" {
-#   application_id = azuread_application.external_dns.application_id
-# }
-
-# resource "azuread_service_principal_password" "external_dns" {
-#   service_principal_id = azuread_service_principal.external_dns.id
-# }
 data "azurerm_resource_group" "external_dns" {
   name = var.azure_dns_zones.resource_group
 }

--- a/k8s-external-dns-azure/iam.tf
+++ b/k8s-external-dns-azure/iam.tf
@@ -27,12 +27,12 @@ data "azurerm_resource_group" "external_dns" {
 
 resource "azurerm_user_assigned_identity" "external_dns" {
   location            = data.azurerm_resource_group.external_dns.location
-  name                = var.md_metadata.name_prefix
+  name                = "${var.md_metadata.name_prefix}-externaldns"
   resource_group_name = data.azurerm_resource_group.external_dns.name
 }
 
 resource "azurerm_federated_identity_credential" "external_dns" {
-  name                = var.md_metadata.name_prefix
+  name                = "${var.md_metadata.name_prefix}-externaldns-fc"
   resource_group_name = data.azurerm_resource_group.external_dns.name
   audience            = ["api://AzureADTokenExchange"]
   issuer              = var.kubernetes_cluster.data.infrastructure.oidc_issuer_url
@@ -55,11 +55,10 @@ resource "kubernetes_secret" "external_dns" {
   }
   data = {
     "azure.json" = jsonencode({
-      tenantId                    = data.azurerm_client_config.current.tenant_id
-      subscriptionId              = data.azurerm_client_config.current.subscription_id
-      resourceGroup               = data.azurerm_resource_group.external_dns.name
-      userAssignedIdentityID      = azurerm_user_assigned_identity.external_dns.id
-      useManagedIdentityExtension = true
+      tenantId                     = data.azurerm_client_config.current.tenant_id
+      subscriptionId               = data.azurerm_client_config.current.subscription_id
+      resourceGroup                = data.azurerm_resource_group.external_dns.name
+      useWorkloadIdentityExtension = true
     })
   }
 }

--- a/k8s-external-dns-azure/main.tf
+++ b/k8s-external-dns-azure/main.tf
@@ -6,6 +6,17 @@ module "external-dns" {
   namespace          = var.namespace
   domain_filters     = local.domain_filters
   helm_additional_values = {
+    podLabels = {
+      "azure.workload.identity/use" = "true"
+    }
+    serviceAccount = {
+      labels = {
+        "azure.workload.identity/use" = "true"
+      }
+      annotations = {
+        "azure.workload.identity/client-id" = azurerm_user_assigned_identity.external_dns.client_id
+      }
+    }
     extraVolumes = [{
       name = "azure-config-file"
       secret = {

--- a/k8s-external-dns/README.md
+++ b/k8s-external-dns/README.md
@@ -9,7 +9,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.10.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.12.1 |
 
 ## Modules
 

--- a/k8s-external-dns/main.tf
+++ b/k8s-external-dns/main.tf
@@ -21,7 +21,7 @@ resource "helm_release" "external-dns" {
   name             = var.release
   chart            = "external-dns"
   repository       = "https://kubernetes-sigs.github.io/external-dns/"
-  version          = "1.7.1"
+  version          = "1.14.3"
   namespace        = var.namespace
   create_namespace = true
 


### PR DESCRIPTION
All documentation and experimentation for getting this to work (and being able to replicate to other services).

References:
* https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/azure.md#managed-identity-using-workload-identity

Results:
```
➜  core-services git:(michael/#ORC-496/multiple-dns-zone-support) ✗ k describe po -n
 md-core-services external-dns-7dd57bcc75-lrl99
Name:             external-dns-7dd57bcc75-lrl99
Namespace:        md-core-services
Priority:         0
Service Account:  external-dns
Node:             aks-default-20161947-vmss000001/10.0.0.126
Start Time:       Wed, 06 Mar 2024 11:59:24 -0800
Labels:           app.kubernetes.io/instance=external-dns
                  app.kubernetes.io/name=external-dns
                  azure.workload.identity/use=true
                  md-manifest=azure-aks-cluster
                  md-package=local-dev-azure-aks-cluster-000
                  md-project=local
                  md-target=dev
                  pod-template-hash=7dd57bcc75
Annotations:      <none>
Status:           Running
SeccompProfile:   RuntimeDefault
IP:               10.0.0.134
IPs:
  IP:           10.0.0.134
Controlled By:  ReplicaSet/external-dns-7dd57bcc75
Containers:
  external-dns:
    Container ID:  containerd://4efd2815a1f7729929f1c3bbc9ee776abb09ac564e02f48a22bb890b5c93d3c7
    Image:         registry.k8s.io/external-dns/external-dns:v0.14.0
    Image ID:      registry.k8s.io/external-dns/external-dns@sha256:474077b3dfccb3021db0a6638274967d0f64ce60dd9730a6f464bee2f78b046f
    Port:          7979/TCP
    Host Port:     0/TCP
    Args:
      --log-level=info
      --log-format=text
      --interval=1m
      --source=service
      --source=ingress
      --policy=sync
      --registry=txt
      --txt-owner-id=local-aks-exdnswi-0002
      --domain-filter=mdazuresbx.com
      --provider=azure
    State:          Running
      Started:      Wed, 06 Mar 2024 11:59:25 -0800
    Ready:          True
    Restart Count:  0
    Requests:
      cpu:      10m
      memory:   32Mi
    Liveness:   http-get http://:http/healthz delay=10s timeout=5s period=10s #success=1 #failure=2
    Readiness:  http-get http://:http/healthz delay=5s timeout=5s period=10s #success=1 #failure=6
    Environment:
      AZURE_CLIENT_ID:             0c16cf57-bb12-4020-bb99-**************
      AZURE_TENANT_ID:             *******************************************
      AZURE_FEDERATED_TOKEN_FILE:  /var/run/secrets/azure/tokens/azure-identity-token
      AZURE_AUTHORITY_HOST:        https://login.microsoftonline.com/
    Mounts:
      /etc/kubernetes from azure-config-file (ro)
      /var/run/secrets/azure/tokens from azure-identity-token (ro)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-v2vjd (ro)
Conditions:
  Type              Status
  Initialized       True
  Ready             True
  ContainersReady   True
  PodScheduled      True
Volumes:
  azure-config-file:
    Type:        Secret (a volume populated by a Secret)
    SecretName:  external-dns-auth
    Optional:    false
  kube-api-access-v2vjd:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
  azure-identity-token:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3600
QoS Class:                   Burstable
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/memory-pressure:NoSchedule op=Exists
                             node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type    Reason     Age   From               Message
  ----    ------     ----  ----               -------
  Normal  Scheduled  26s   default-scheduler  Successfully assigned md-core-services/external-dns-7dd57bcc75-lrl99 to aks-default-20161947-vmss000001
  Normal  Pulled     26s   kubelet            Container image "registry.k8s.io/external-dns/external-dns:v0.14.0" already present on machine
  Normal  Created    26s   kubelet            Created container external-dns
  Normal  Started    25s   kubelet            Started container external-dns
```
```
➜  core-services git:(michael/#ORC-496/multiple-dns-zone-support) ✗ k logs -n md-cor
e-services external-dns-7dd57bcc75-lrl99
time="2024-03-06T19:59:25Z" level=info msg="Instantiating new Kubernetes client"
time="2024-03-06T19:59:25Z" level=info msg="Using inCluster-config based on serviceaccount-token"
time="2024-03-06T19:59:25Z" level=info msg="Created Kubernetes client https://172.20.0.1:443"
time="2024-03-06T19:59:25Z" level=info msg="Using workload identity extension to retrieve access token for Azure API."
time="2024-03-06T19:59:26Z" level=info msg="All records are already up to date"
```
```
➜  core-services git:(michael/#ORC-496/multiple-dns-zone-support) ✗ k describe sa -n
 md-core-services external-dns
Name:                external-dns
Namespace:           md-core-services
Labels:              app.kubernetes.io/instance=external-dns
                     app.kubernetes.io/managed-by=Helm
                     app.kubernetes.io/name=external-dns
                     app.kubernetes.io/version=0.14.0
                     azure.workload.identity/use=true
                     helm.sh/chart=external-dns-1.14.3
Annotations:         azure.workload.identity/client-id: 0c16cf57-bb12-4020-bb99-*************
                     meta.helm.sh/release-name: external-dns
                     meta.helm.sh/release-namespace: md-core-services
Image pull secrets:  <none>
Mountable secrets:   <none>
Tokens:              <none>
Events:              <none>
```
![image](https://github.com/massdriver-cloud/terraform-modules/assets/8037512/b91cd352-fb65-4716-b7e0-17d12502917e)
![image](https://github.com/massdriver-cloud/terraform-modules/assets/8037512/303774be-34a5-4adb-8c45-382737bc06f1)
