### PR TITLE
Adding k8s-external-dns-azure multiple DNS zone support

### DIFF
--- a/k8s-external-dns-azure/iam.tf
+++ b/k8s-external-dns-azure/iam.tf
@@ -29,8 +29,10 @@ resource "azurerm_role_assignment" "external_dns" {
 }
 
 resource "kubernetes_secret" "external_dns" {
+  for_each = { for zone in var.azure_dns_zones.dns_zones : zone => zone }
+
   metadata {
-    name      = "external-dns-auth"
+    name      = "external-dns-auth-${each.value}"
     namespace = var.namespace
     labels    = var.md_metadata.default_tags
   }

--- a/k8s-external-dns-azure/main.tf
+++ b/k8s-external-dns-azure/main.tf
@@ -1,15 +1,16 @@
 module "external-dns" {
+  for_each           = { for zone in var.azure_dns_zones.dns_zones : zone => zone }
   source             = "../k8s-external-dns"
   md_metadata        = var.md_metadata
   kubernetes_cluster = var.kubernetes_cluster
-  release            = var.release
+  release            = regex("^[a-z0-9-]+", "${var.release}-${each.value}")
   namespace          = var.namespace
   domain_filters     = local.domain_filters
   helm_additional_values = {
     extraVolumes = [{
       name = "azure-config-file"
       secret = {
-        secretName = kubernetes_secret.external_dns.metadata[0].name
+        secretName = kubernetes_secret.external_dns[each.key].metadata[0].name
         items = [{
           key  = "azure.json"
           path = "azure.json"


### PR DESCRIPTION
Customer requested. 

Iterating through list of given Azure DNS zones, then creating an External DNS instance and a Kubernetes secret per zone.

Issue facing: Multiple instances deploying but they are not creating records in Azure. Current theory is that the kubernetes secret metadata name must be set to `external-dns-auth` for the secret to be used.

Related: https://github.com/massdriver-cloud/azure-aks-cluster/pull/76