### PR TITLE
Experimenting with schemas tied to reusable modules

### DIFF
--- a/aws/forecasted-monthly-cost-budget/README.md
+++ b/aws/forecasted-monthly-cost-budget/README.md
@@ -1,0 +1,3 @@
+# AWS Budget Management Terraform Module
+
+This Terraform module provides a simple and flexible way to manage AWS budgets, allowing users to monitor and control their AWS spending. It creates a budget that tracks the cost of your AWS resources and notifies you when your spending exceeds predefined thresholds.

--- a/aws/forecasted-monthly-cost-budget/main.tf
+++ b/aws/forecasted-monthly-cost-budget/main.tf
@@ -1,0 +1,51 @@
+variable "name_suffix" {
+  type    = string
+  default = null
+}
+
+variable "limit_amount" {
+  default = 500
+}
+
+variable "subscriber_email_addresses" {
+  default = []
+}
+
+variable "subscriber_sns_topic_arns" {
+  default = []
+}
+
+variable "md_metadata" {
+  type = any
+}
+
+locals {
+  name              = var.name_suffix != null ? var.md_metadata.name_prefix + "-" + var.name_suffix : var.md_metadata.name_prefix
+  package_tag_value = var.md_metadata.default_tags["md-package"]
+}
+
+resource "aws_budgets_budget" "main" {
+  name         = local.name
+  budget_type  = "COST"
+  limit_amount = var.limit_amount
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  cost_filter {
+    name = "TagKeyValue"
+    values = [
+      "md-package${"$"}${local.package_tag_value}"
+    ]
+  }
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "FORECASTED"
+    subscriber_email_addresses = var.subscriber_email_addresses
+    subscriber_sns_topic_arns  = var.subscriber_sns_topic_arns
+  }
+
+  tags = var.md_metadata.default_tags
+}

--- a/aws/forecasted-monthly-cost-budget/schema.json
+++ b/aws/forecasted-monthly-cost-budget/schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "title": "Forecasted Monthly Cost Budget",
+  "description": "AWS budget to monitor and manage cloud costs. Sets a monthly spending limit. If the forecasted spending exceeds 100% of this limit, it triggers notifications.",
+  "properties": {
+    "limit_amount": {
+      "type": "string",
+      "title": "Monthly Spending Limit",
+      "description": "The maximum amount of money that can be spent per month."
+    },
+    "email_addresses": {
+      "type": "array",
+      "title": "Notification Email Addresses",
+      "description": "The email addresses to which notifications will be sent when the forecasted spending exceeds the monthly spending limit.",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "limit_amount"
+  ]
+}


### PR DESCRIPTION
I've been asked about setting budgets in the UI on 4 demos this week. I want to experiment with showing how _the user_ can extend the platform w/ reusable schemas and opentofu/terraform modules.

This will effectively be a module that you can bring into tf, but also includes a small json schema that you can import into your md yaml file.